### PR TITLE
Hiding inner navigation bar for "Warranty" and "Shipping and Returns"

### DIFF
--- a/src/app/(main)/policies/shipping-policy/page.tsx
+++ b/src/app/(main)/policies/shipping-policy/page.tsx
@@ -7,12 +7,12 @@ import PolicyDetail from '@/components/policy/PolicyDetail';
 import PolicyFurtherAssistance from '@/components/policy/PolicyFurtherAssistance';
 import { usePathname } from 'next/navigation';
 
-function ShippingPolicy() {
+function ShippingPolicy({ hideHeader }: { hideHeader?: boolean }) {
   const path = usePathname();
   const isSeatCovers = path === '/seat-covers';
   return (
     <>
-      <PolicyHeader headerText="Shipping Policy" />
+      <PolicyHeader hideHeader={hideHeader} headerText="Shipping Policy" />
       <div className="lg:mx-auto lg:flex lg:w-[842px] lg:flex-col lg:justify-center">
         <div className="relative px-5 py-5 lg:py-14">
           <PolicyTitle title="Free Delivery" uppercase />

--- a/src/app/(main)/policies/shipping-policy/page.tsx
+++ b/src/app/(main)/policies/shipping-policy/page.tsx
@@ -7,12 +7,12 @@ import PolicyDetail from '@/components/policy/PolicyDetail';
 import PolicyFurtherAssistance from '@/components/policy/PolicyFurtherAssistance';
 import { usePathname } from 'next/navigation';
 
-function ShippingPolicy({ hideHeader }: { hideHeader?: boolean }) {
+function ShippingPolicy({ showHeader }: { showHeader?: boolean }) {
   const path = usePathname();
   const isSeatCovers = path === '/seat-covers';
   return (
     <>
-      <PolicyHeader hideHeader={hideHeader} headerText="Shipping Policy" />
+      <PolicyHeader showHeader={showHeader} headerText="Shipping Policy" />
       <div className="lg:mx-auto lg:flex lg:w-[842px] lg:flex-col lg:justify-center">
         <div className="relative px-5 py-5 lg:py-14">
           <PolicyTitle title="Free Delivery" uppercase />

--- a/src/app/(main)/policies/warranty-policy/page.tsx
+++ b/src/app/(main)/policies/warranty-policy/page.tsx
@@ -7,7 +7,7 @@ import PolicyDetail from '@/components/policy/PolicyDetail';
 import PolicyFurtherAssistance from '@/components/policy/PolicyFurtherAssistance';
 import { usePathname } from 'next/navigation';
 
-function WarrantyPolicy({ hideHeader }: { hideHeader?: boolean }) {
+function WarrantyPolicy({ showHeader }: { showHeader?: boolean }) {
   const path = usePathname();
   const isSeatCovers = path === '/seat-covers';
   let warrantyLength = 'A LIFETIME';
@@ -17,7 +17,7 @@ function WarrantyPolicy({ hideHeader }: { hideHeader?: boolean }) {
 
   return (
     <>
-       <PolicyHeader hideHeader={hideHeader} headerText="Warranty" />
+      <PolicyHeader showHeader={showHeader} headerText="Warranty" />
       <div className="lg:mx-auto lg:flex lg:w-[842px] lg:flex-col lg:justify-center">
         <div className="relative px-5 pb-4 lg:py-14">
           <PolicyTitle

--- a/src/app/(main)/policies/warranty-policy/page.tsx
+++ b/src/app/(main)/policies/warranty-policy/page.tsx
@@ -17,7 +17,7 @@ function WarrantyPolicy({ hideHeader }: { hideHeader?: boolean }) {
 
   return (
     <>
-      {!hideHeader && <PolicyHeader headerText="Warranty" />}
+       <PolicyHeader hideHeader={hideHeader} headerText="Warranty" />
       <div className="lg:mx-auto lg:flex lg:w-[842px] lg:flex-col lg:justify-center">
         <div className="relative px-5 pb-4 lg:py-14">
           <PolicyTitle

--- a/src/components/PDP/MobilePDPDetails.tsx
+++ b/src/components/PDP/MobilePDPDetails.tsx
@@ -172,7 +172,7 @@ export const MobilePDPDetails = () => {
                 ref={warRef}
               >
                 <div className="-mx-5 mt-[20px]">
-                  <WarrantyPolicy hideHeader />
+                  <WarrantyPolicy showHeader />
                 </div>
               </div>
             </StickySheetItem>

--- a/src/components/PDP/components/ExtraDetailsTabs.tsx
+++ b/src/components/PDP/components/ExtraDetailsTabs.tsx
@@ -13,8 +13,8 @@ export default function ExtraDetailsTabs() {
     ?.toLowerCase()
     .startsWith('/seat-covers/leatherette');
   const otherDetailsBar = [
-    { title: 'Shipping & Returns', jsx: <ShippingPolicy hideHeader={true} /> },
-    { title: 'Warranty', jsx: <WarrantyPolicy hideHeader={true} /> },
+    { title: 'Shipping & Returns', jsx: <ShippingPolicy showHeader={false} /> },
+    { title: 'Warranty', jsx: <WarrantyPolicy showHeader={false} /> },
   ];
 
   if (!isSeatCovers && !isLeatherette) {

--- a/src/components/PDP/components/ExtraDetailsTabs.tsx
+++ b/src/components/PDP/components/ExtraDetailsTabs.tsx
@@ -13,8 +13,8 @@ export default function ExtraDetailsTabs() {
     ?.toLowerCase()
     .startsWith('/seat-covers/leatherette');
   const otherDetailsBar = [
-    { title: 'Shipping & Returns', jsx: <ShippingPolicy /> },
-    { title: 'Warranty', jsx: <WarrantyPolicy /> },
+    { title: 'Shipping & Returns', jsx: <ShippingPolicy hideHeader={true} /> },
+    { title: 'Warranty', jsx: <WarrantyPolicy hideHeader={true} /> },
   ];
 
   if (!isSeatCovers && !isLeatherette) {

--- a/src/components/PDP/components/ReviewSection.tsx
+++ b/src/components/PDP/components/ReviewSection.tsx
@@ -317,7 +317,7 @@ const ReviewSection = () => {
       )}
       <div className="flex flex-col gap-[20px] lg:flex-row  lg:gap-0">
         <div className="flex w-full min-w-[188px] flex-col lg:items-center">
-          <div className="flex items-center gap-[14px] pt-8 lg:pt-0">
+          <div className="flex items-center gap-[14px] lg:pt-0">
             <p className="pl-4 text-[40px] font-black lg:pl-0 lg:text-[80px]">
               {average_score?.toFixed(1) || '4.9'}
             </p>

--- a/src/components/policy/PolicyHeader.tsx
+++ b/src/components/policy/PolicyHeader.tsx
@@ -5,6 +5,7 @@ import PolicyTabs from './PolicyTabs';
 
 type PolicyHeaderProps = {
   headerText: string;
+  hideHeader?: boolean | undefined;
 };
 
 const raleway = Raleway({
@@ -15,7 +16,10 @@ const raleway = Raleway({
   variable: '--font-raleway',
 });
 
-export default function PolicyHeader({ headerText }: PolicyHeaderProps) {
+export default function PolicyHeader({
+  headerText,
+  hideHeader,
+}: PolicyHeaderProps) {
   return (
     <>
       <div className="relative">
@@ -35,7 +39,7 @@ export default function PolicyHeader({ headerText }: PolicyHeaderProps) {
           </p>
         </div>
       </div>
-      <PolicyTabs />
+      {!hideHeader && <PolicyTabs />}
     </>
   );
 }

--- a/src/components/policy/PolicyHeader.tsx
+++ b/src/components/policy/PolicyHeader.tsx
@@ -5,7 +5,7 @@ import PolicyTabs from './PolicyTabs';
 
 type PolicyHeaderProps = {
   headerText: string;
-  hideHeader?: boolean | undefined;
+  showHeader?: boolean | undefined;
 };
 
 const raleway = Raleway({
@@ -18,7 +18,7 @@ const raleway = Raleway({
 
 export default function PolicyHeader({
   headerText,
-  hideHeader,
+  showHeader = true,
 }: PolicyHeaderProps) {
   return (
     <>
@@ -39,7 +39,7 @@ export default function PolicyHeader({
           </p>
         </div>
       </div>
-      {!hideHeader && <PolicyTabs />}
+      {showHeader && <PolicyTabs />}
     </>
   );
 }


### PR DESCRIPTION
- This change can be found in ExtraDetailsTabs component
- This is a Calvin request and cannot be found in figma