### PR TITLE
If Premium-Plus is not in the URL, redirect to it. Remove Suggested Products

### DIFF
--- a/src/app/(main)/[productType]/[coverType]/page.tsx
+++ b/src/app/(main)/[productType]/[coverType]/page.tsx
@@ -28,6 +28,7 @@ export async function generateMetadata({ params }: { params: TPathParams }) {
   };
 }
 const coverTypes = ['premium-plus', 'premium', 'standard-pro', 'standard'];
+const productTypes = ['car-covers', 'truck-covers', 'suv-covers'];
 
 export default async function CarPDPModelDataLayer({
   params,
@@ -35,7 +36,10 @@ export default async function CarPDPModelDataLayer({
   params: TPathParams;
 }) {
   const coverType = params.coverType;
-  if (!coverTypes.includes(coverType as string)) {
+  if (
+    !productTypes.includes(params.productType) ||
+    !coverTypes.includes(coverType as string)
+  ) {
     notFound();
   }
   let reviewData: TReviewData[] = [];

--- a/src/app/(main)/[productType]/components/AddToCart.tsx
+++ b/src/app/(main)/[productType]/components/AddToCart.tsx
@@ -86,7 +86,7 @@ export default function AddToCart({
       {isTypeOrCoverPage && !isSticky ? (
         <VehicleSelector searchParams={searchParams} />
       ) : (
-        <div className="fixed inset-x-0 bottom-0 z-[1] flex bg-white p-4 lg:relative lg:p-1">
+        <div className="fixed inset-x-0 bottom-0 z-20 flex bg-white p-4 lg:relative lg:p-1">
           <Button
             className=" h-[48px] w-full rounded bg-[#BE1B1B] text-lg font-bold uppercase text-white disabled:bg-[#BE1B1B] lg:h-[62px]"
             onClick={() => {

--- a/src/app/(main)/[productType]/components/FeaturesAndProductsSection.tsx
+++ b/src/app/(main)/[productType]/components/FeaturesAndProductsSection.tsx
@@ -6,7 +6,7 @@ export default function FeaturesAndProductsSection() {
   return (
     <SeeAllSectionClientWrapper
       child1={<FeaturesSection />}
-      child2={<SuggestedProducts />}
+      // child2={<SuggestedProducts />}
     ></SeeAllSectionClientWrapper>
   );
 }

--- a/src/app/(main)/[productType]/components/SeeAllSectionClientWrapper.tsx
+++ b/src/app/(main)/[productType]/components/SeeAllSectionClientWrapper.tsx
@@ -21,9 +21,9 @@ export default function SeeAllSectionClientWrapper({ child1, child2 }) {
       >
         {child1}
         <div
-          className={`absolute ${seeAllVisible ? '' : 'hidden'} -bottom-[1px] z-[5] w-full bg-gradient-to-t from-white from-85%`}
+          className={`absolute ${seeAllVisible ? '' : 'hidden'} -bottom-[1px] z-[5] w-full bg-gradient-to-t from-white from-80%`}
         >
-          <div className="flex  flex-col items-center justify-center pt-[10vh]">
+          <div className="flex  flex-col items-center justify-center pb-[2vh] pt-[5vh]">
             <div
               onClick={() => setSeeAllVisible(false)}
               className="flex cursor-pointer flex-col items-center"
@@ -36,18 +36,18 @@ export default function SeeAllSectionClientWrapper({ child1, child2 }) {
               </div>
             </div>
           </div>
-          {child2}
+          {/* {child2} */}
         </div>
       </section>
       <section className={`${seeAllVisible ? 'hidden' : 'block'}`}>
         <span className="max-w-[100vw] bg-white">
-          <div className="flex w-full flex-col justify-center px-4">
+          <div className="flex w-full flex-col justify-center px-4 pb-3">
             <EnhancedProtectionSection />
             {isDefaultCoverType && <RealTestSection />}
             {isDefaultCoverType && <ProvenSection />}
             <WarrantySection />
           </div>
-          <SuggestedProducts />
+          {/* <SuggestedProducts /> */}
         </span>
       </section>
     </>

--- a/src/components/PDP/components/MobileProductDetails.tsx
+++ b/src/components/PDP/components/MobileProductDetails.tsx
@@ -17,7 +17,7 @@ export default function MobileProductDetails() {
       <div className="px-4 pt-8 lg:pt-[100px]">
         <Layers seeMore={seeMore} setSeeMore={setSeeMore} />
       </div>
-      <SuggestedProducts />
+      {/* <SuggestedProducts /> */}
     </div>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  const search = request.nextUrl.search;
+
+  const segments = pathname.split('/').filter(Boolean);
+  const productTypes = ['car-covers', 'suv-covers', 'truck-covers'];
+  const coverTypes = ['premium', 'premium-plus', 'standard', 'standard-pro'];
+
+  if (productTypes.includes(segments[0])) {
+    if (
+      segments.length > 1 &&
+      !coverTypes.some((type) => segments.includes(type))
+    ) {
+      return NextResponse.redirect(
+        new URL(
+          `/${segments[0]}/premium-plus/${segments.slice(1).join('/')}${search}`,
+          request.url
+        ),
+        301
+      );
+    }
+  }
+  return NextResponse.next();
+}


### PR DESCRIPTION
Ex: https://coverland.com/car-covers/pontiac/safari/1958-1964 shows error
Should go to https://coverland.com/car-covers/premium-plus/pontiac/safari/1958-1964

## How to test
- Test different options on different product types
- Test other cover types still work
- Test with submodels and submodel 2
- Just try to break it 
- Check SuggestProducts does not show

## KNOWN ISSUE
- IF a user does like /car-covers/prem it'll do /car-covers/premium-plus/prem. I think this is fine for now since users should just not misspell shit y'kno but if this is a problem, we can look into a fuzzy search library to help autocorrect
