### PR TITLE
Replaced footer instagram link

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -63,7 +63,7 @@ const Footer = () => {
               </IconCircle>
             </Link>
             <Link
-              href="https://www.instagram.com/coverland_us/?hl=ko"
+              href="https://www.instagram.com/coverland_us/"
               target="_blank"
               aria-label="Go to Coverland Instagram page"
             >


### PR DESCRIPTION
- Routed instagram footer link to english page instead of korean