### PR TITLE
Implemented SKU Lab Order Creation Upon Payment Confirmation

### DIFF
--- a/src/app/api/meta/event/route.ts
+++ b/src/app/api/meta/event/route.ts
@@ -13,7 +13,6 @@ export async function POST(request: NextRequest) {
     const { metaCPIEvent: event } = await request.json();
     event.user_data.client_ip_address = request?.headers.get('x-forwarded-for')
     event.event_source_url = request.headers.get('referer') || ""
-    console.log('[Event]:', event);
     
     const response = await fetch(
       `https://graph.facebook.com/v19.0/${process.env.META_PIXEL_ID}/events?access_token=${process.env.META_CAPI_ACCESS_TOKEN}`,

--- a/src/app/api/sku-labs/orders/route.ts
+++ b/src/app/api/sku-labs/orders/route.ts
@@ -1,57 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-// Define the type for items within the stash
-type SkuLabItem = {
-  quantity: number;
-  price: number;
-  type: string;
-  id: string;
-  lineSku: string;
-  lineName: string;
-};
-
-// Define the type for shipping information within the stash
-type SkuLabShippingInformation = {
-  name: string;
-  phone: string;
-  email: string;
-  company: string;
-  city: string;
-  country: string;
-  state: string;
-  zip: string;
-  address: string;
-  address_2: string;
-  method: string;
-};
-
-// Define the type for the stash itself
-type SkuLabStash = {
-  store_id: string;
-  type: string;
-  id: string;
-  notes: string;
-  date: string;
-  items: SkuLabItem[];
-  discount: number;
-  shipping: number;
-  financial_status: string;
-  tax: number;
-  total: number;
-  shipping_information: SkuLabShippingInformation;
-  tags: string[];
-};
-
-// Define the type for the main structure
-type SkuLabOrderDTO = {
-  store_id: string;
-  order_number: string;
-  stash: SkuLabStash;
+export type SkuLabOrderResponse = {
+  data?: {
+    success: boolean;
+    store_id: string;
+    order_number: string;
+  };
+  error?: string;
+  status?: number;
 };
 
 const SKU_LAB_URL = 'https://api.skulabs.com';
 
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<SkuLabOrderResponse> {
   // TODO: Probably good to have schema validation here
   const { order } = await request.json();
   if (!order) {
@@ -77,6 +38,7 @@ export async function POST(request: NextRequest) {
     console.info('[SkulabPost] Data:', data);
     return NextResponse.json({
       data,
+      status: 200,
     });
   } catch (error) {
     console.error(

--- a/src/app/api/sku-labs/orders/route.ts
+++ b/src/app/api/sku-labs/orders/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Define the type for items within the stash
+type SkuLabItem = {
+  quantity: number;
+  price: number;
+  type: string;
+  id: string;
+  lineSku: string;
+  lineName: string;
+};
+
+// Define the type for shipping information within the stash
+type SkuLabShippingInformation = {
+  name: string;
+  phone: string;
+  email: string;
+  company: string;
+  city: string;
+  country: string;
+  state: string;
+  zip: string;
+  address: string;
+  address_2: string;
+  method: string;
+};
+
+// Define the type for the stash itself
+type SkuLabStash = {
+  store_id: string;
+  type: string;
+  id: string;
+  notes: string;
+  date: string;
+  items: SkuLabItem[];
+  discount: number;
+  shipping: number;
+  financial_status: string;
+  tax: number;
+  total: number;
+  shipping_information: SkuLabShippingInformation;
+  tags: string[];
+};
+
+// Define the type for the main structure
+type SkuLabOrderDTO = {
+  store_id: string;
+  order_number: string;
+  stash: SkuLabStash;
+};
+
+const SKU_LAB_URL = 'https://api.skulabs.com';
+
+export async function POST(request: NextRequest) {
+  // TODO: Probably good to have schema validation here
+  const { order } = await request.json();
+  if (!order) {
+    return NextResponse.json({ error: 'Order info is required', status: 400 });
+  }
+  try {
+    const response = await fetch(`${SKU_LAB_URL}/order/add`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.SKU_LABS_API_KEY}`,
+      },
+      body: JSON.stringify({
+        ...order,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error('[SKU Labs Orders POST]: Network response was not ok');
+    }
+
+    const data = await response.json();
+    console.info('[SkulabPost] Data:', data);
+    return NextResponse.json({
+      data,
+    });
+  } catch (error) {
+    console.error(
+      '[SKU Lab Orders POST]: An unexpected error occurred:',
+      error
+    );
+    return NextResponse.json(
+      { error: '[SKU Lab Orders POST]: An unexpected error occurred' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/checkout/PayPalButtonSection.tsx
+++ b/src/components/checkout/PayPalButtonSection.tsx
@@ -23,6 +23,7 @@ import { handlePurchaseGoogleTag } from '@/hooks/useGoogleTagDataLayer';
 import { hashData } from '@/lib/utils/hash';
 import { getCookie } from '@/lib/utils/cookie';
 import { v4 as uuidv4 } from 'uuid';
+import { generateSkuLabOrderInput } from '@/lib/utils/skuLabs';
 
 export default function PayPalButtonSection() {
   const { clearLocalStorageCart, getTotalPrice, cartItems } = useCartContext();
@@ -199,6 +200,27 @@ export default function PayPalButtonSection() {
                   },
                 });
               }
+
+              const skuLabOrderInput = generateSkuLabOrderInput({
+                orderNumber,
+                cartItems,
+                totalMsrpPrice,
+                shippingAddress,
+                customerInfo,
+              });
+    
+              // SKU Labs Order Creation
+              // Post Items
+              const skuLabCreateOrderResponse = await fetch(
+                '/api/sku-labs/orders',
+                {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({ order: skuLabOrderInput }),
+                }
+              );
 
               const enhancedGoogleConversionInput = {
                 email: customerInfo.email || '',

--- a/src/components/checkout/Payment.tsx
+++ b/src/components/checkout/Payment.tsx
@@ -11,6 +11,7 @@ import { PaymentMethod, StripeAddress } from '@/lib/types/checkout';
 import BillingAddress from './BillingAddress';
 import { useCartContext } from '@/providers/CartProvider';
 import {
+  convertPriceFromStripeFormat,
   convertPriceToStripeFormat,
   getSkuQuantityPriceFromCartItemsForMeta,
   getSkusFromCartItems,
@@ -242,7 +243,7 @@ export default function Payment() {
           const skuLabOrderInput = generateSkuLabOrderInput({
             orderNumber,
             cartItems,
-            totalMsrpPrice,
+            totalMsrpPrice: convertPriceFromStripeFormat(totalMsrpPrice),
             shippingAddress,
             customerInfo,
           });

--- a/src/components/checkout/Payment.tsx
+++ b/src/components/checkout/Payment.tsx
@@ -138,6 +138,7 @@ export default function Payment() {
           result.paymentIntent &&
           result.paymentIntent.status === 'succeeded'
         ) {
+          // SendGrid Thank You Email
           const emailInput = {
             to: customerInfo.email,
             name: {
@@ -170,6 +171,7 @@ export default function Payment() {
             );
           }
 
+          // Meta Conversion API
           const skus = getSkusFromCartItems(cartItems);
           const skusWithQuantityMsrpForMeta =
             getSkuQuantityPriceFromCartItemsForMeta(cartItems);
@@ -244,6 +246,7 @@ export default function Payment() {
             });
           }
 
+          // Google Conversion API
           const enhancedGoogleConversionInput = {
             email: customerInfo.email || '',
             phone_number: shippingAddress.phone || '',
@@ -256,18 +259,73 @@ export default function Payment() {
             country: shippingAddress.address.country || '',
           };
 
-          handlePurchaseGoogleTag(
-            cartItems,
-            orderNumber,
-            getTotalPrice().toFixed(2),
-            clearLocalStorageCart,
-            enhancedGoogleConversionInput
+          // handlePurchaseGoogleTag(
+          //   cartItems,
+          //   orderNumber,
+          //   getTotalPrice().toFixed(2),
+          //   clearLocalStorageCart,
+          //   enhancedGoogleConversionInput
+          // );
+
+          const exampleOrder = {
+            store_id: '62f0fcbffc3f4e916f865d6a',
+            order_number: orderNumber,
+            stash: {
+              store_id: '62f0fcbffc3f4e916f865d6a',
+              type: 'manual',
+              id: orderNumber,
+              notes: 'TEST ORDER',
+              date: '2024-06-07T13:01:00-07:00',
+              items: [
+                {
+                  quantity: 1,
+                  price: 279.95,
+                  type: 'item',
+                  id: '66283531141d505bdb1c491b',
+                  lineSku: 'CA-SC-10-FB-125-BK-1TO',
+                  lineName: 'Car Seat Cover FB-125 (Full Set) - Black',
+                },
+              ],
+              discount: 0,
+              shipping: 0,
+              financial_status: '',
+              tax: 0,
+              total: 279.95,
+              shipping_information: {
+                name: 'William Test User',
+                phone: '16267368476',
+                email: 'dev.william.coverland@gmail.com',
+                company: 'Coverland',
+                city: 'Norwalk',
+                country: 'US',
+                state: 'CA',
+                zip: '90650',
+                address: '15529 Blackburn Ave',
+                address_2: '',
+                method: '2 day free shipping',
+              },
+              tags: ['Coverland'],
+            },
+          };
+
+          // SKU Labs Order Creation
+          // Post Items
+          const skuLabCreateOrderResponse = await fetch(
+            '/api/sku-labs/orders',
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ order: exampleOrder }),
+            }
           );
+          debugger;
 
           const { id, client_secret } = result.paymentIntent;
-          router.push(
-            `/thank-you?order_number=${orderNumber}&payment_intent=${id}&payment_intent_client_secret=${client_secret}`
-          );
+          // router.push(
+          //   `/thank-you?order_number=${orderNumber}&payment_intent=${id}&payment_intent_client_secret=${client_secret}`
+          // );
         }
       })
       .finally(() => {

--- a/src/contexts/CheckoutContext.tsx
+++ b/src/contexts/CheckoutContext.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 
-type CustomerInfo = {
+export type CustomerInfo = {
   email: string;
   phoneNumber: string;
 };

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon';
+
 // Example: 1713216693  -> April 15, 2024, at 21:31:33
 export const convertUnixTimestampToUTCDate = (timestamp: number) => {
   // Convert Unix timestamp to milliseconds by multiplying by 1000
@@ -23,11 +25,17 @@ export const getCurrentTimeInISOFormat = () => {
 
 // Outputs: "May 10, 2024" (if today is May 10, 2024)
 export const getCurrentDayInLocaleDateString = () => {
-  const date = new Date(); 
+  const date = new Date();
   const formattedDate = date.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   });
-  return formattedDate; 
+  return formattedDate;
+};
+
+// Output Example: 2024-06-07T13:01:00-07:00
+export const getCurrentDateInPST = () => {
+  const pstDate = DateTime.now().setZone('America/Los_Angeles').toISO();
+  return pstDate;
 };

--- a/src/lib/utils/skuLabs.ts
+++ b/src/lib/utils/skuLabs.ts
@@ -2,7 +2,6 @@ import { CustomerInfo } from '@/contexts/CheckoutContext';
 import { TCartItem } from '../cart/useCart';
 import { StripeAddress } from '../types/checkout';
 import { getCurrentDateInPST } from './date';
-import { convertPriceFromStripeFormat } from './stripe';
 
 // Define the type for items within the stash
 type SkuLabItem = {
@@ -113,7 +112,7 @@ export const generateSkuLabOrderInput = ({
       shipping: 0, // TODO: Currently no shipping, but need to update later
       financial_status: '',
       tax: 0, // Currently no tax
-      total: convertPriceFromStripeFormat(totalMsrpPrice),
+      total: totalMsrpPrice,
       shipping_information: {
         name: shippingAddress.name,
         phone: shippingAddress.phone || '',

--- a/src/lib/utils/skuLabs.ts
+++ b/src/lib/utils/skuLabs.ts
@@ -61,6 +61,12 @@ type SkuLabOrderInput = {
   customerInfo: CustomerInfo;
 };
 
+// 
+/**
+ * Generates the note for SKU Labs so CSRs can see SKU, item name, and quantity
+ * @param cartItems 
+ * @returns 
+ */
 const generateNote = (cartItems: TCartItem[]) => {
   const skuNameQuantity = cartItems.map((cartItem: TCartItem) => {
     const itemName =
@@ -76,6 +82,7 @@ const generateNote = (cartItems: TCartItem[]) => {
 
   return skuNameQuantity.join('\n');
 };
+
 export const generateSkuLabOrderInput = ({
   orderNumber,
   cartItems,

--- a/src/lib/utils/skuLabs.ts
+++ b/src/lib/utils/skuLabs.ts
@@ -4,6 +4,55 @@ import { StripeAddress } from '../types/checkout';
 import { getCurrentDateInPST } from './date';
 import { convertPriceFromStripeFormat } from './stripe';
 
+// Define the type for items within the stash
+type SkuLabItem = {
+  quantity: number;
+  price: number;
+  type: string;
+  id?: string; // temp optional
+  lineSku?: string; // temp optional
+  lineName?: string; // temp optional
+};
+
+// Define the type for shipping information within the stash
+type SkuLabShippingInformation = {
+  name: string;
+  phone: string;
+  email: string;
+  company: string;
+  city: string;
+  country: string;
+  state: string;
+  zip: string;
+  address: string;
+  address_2: string;
+  method: string;
+};
+
+// Define the type for the stash itself
+type SkuLabStash = {
+  store_id: string;
+  type: string;
+  id: string;
+  notes: string;
+  date: string;
+  items: SkuLabItem[];
+  discount: number;
+  shipping: number;
+  financial_status: string;
+  tax: number;
+  total: number;
+  shipping_information: SkuLabShippingInformation;
+  tags: string[];
+};
+
+// Define the type for the main structure
+type SkuLabOrderDTO = {
+  store_id: string;
+  order_number: string;
+  stash: SkuLabStash;
+};
+
 type SkuLabOrderInput = {
   orderNumber: string;
   cartItems: TCartItem[];
@@ -33,7 +82,7 @@ export const generateSkuLabOrderInput = ({
   totalMsrpPrice,
   shippingAddress,
   customerInfo,
-}: SkuLabOrderInput) => {
+}: SkuLabOrderInput): SkuLabOrderDTO => {
   const notes = generateNote(cartItems);
   return {
     store_id: '62f0fcbffc3f4e916f865d6a', // Hard Coded for now
@@ -43,10 +92,10 @@ export const generateSkuLabOrderInput = ({
       type: 'manual',
       id: orderNumber,
       notes: notes,
-      date: getCurrentDateInPST(),
+      date: getCurrentDateInPST() as string,
       items: cartItems.map((cartItem) => ({
-        quantity: cartItem.quantity,
-        price: cartItem.msrp,
+        quantity: cartItem.quantity as number,
+        price: cartItem.msrp as number,
         type: 'item', // Item Or Kit (for Full Seat Cover bundle)
         // lineSku: '', // In the future will need to grab the SKU Lab sku
         // id: '' // In the future need to grab SKU Lab item id
@@ -60,15 +109,15 @@ export const generateSkuLabOrderInput = ({
       total: convertPriceFromStripeFormat(totalMsrpPrice),
       shipping_information: {
         name: shippingAddress.name,
-        phone: shippingAddress.phone,
+        phone: shippingAddress.phone || '',
         email: customerInfo.email,
         company: '',
-        city: shippingAddress.address.city,
+        city: shippingAddress.address.city || '',
         country: shippingAddress.address.country,
-        state: shippingAddress.address.state,
-        zip: shippingAddress.address.postal_code,
-        address: shippingAddress.address.line1,
-        address_2: shippingAddress.address.line2,
+        state: shippingAddress.address.state || '',
+        zip: shippingAddress.address.postal_code || '',
+        address: shippingAddress.address.line1 || '',
+        address_2: shippingAddress.address.line2 || '',
         method: '2 day free shipping',
       },
       tags: ['Coverland'],

--- a/src/lib/utils/skuLabs.ts
+++ b/src/lib/utils/skuLabs.ts
@@ -1,0 +1,77 @@
+import { CustomerInfo } from '@/contexts/CheckoutContext';
+import { TCartItem } from '../cart/useCart';
+import { StripeAddress } from '../types/checkout';
+import { getCurrentDateInPST } from './date';
+import { convertPriceFromStripeFormat } from './stripe';
+
+type SkuLabOrderInput = {
+  orderNumber: string;
+  cartItems: TCartItem[];
+  totalMsrpPrice: number;
+  shippingAddress: StripeAddress;
+  customerInfo: CustomerInfo;
+};
+
+const generateNote = (cartItems: TCartItem[]) => {
+  const skuNameQuantity = cartItems.map((cartItem: TCartItem) => {
+    const itemName =
+      `${cartItem?.year_generation || ''} ${cartItem?.make || ''} ${cartItem?.model || ''} ${
+        cartItem?.submodel1 ? cartItem?.submodel1 : ''
+      } ${cartItem?.submodel2 ? cartItem?.submodel2 : ''} ${cartItem.type} ${cartItem?.display_id} ${
+        cartItem?.display_color
+      }`
+        .replace(/\s+/g, ' ')
+        .trim();
+    return `${cartItem.sku} ${itemName} Quantity: ${cartItem.quantity}`;
+  });
+
+  return skuNameQuantity.join('\n');
+};
+export const generateSkuLabOrderInput = ({
+  orderNumber,
+  cartItems,
+  totalMsrpPrice,
+  shippingAddress,
+  customerInfo,
+}: SkuLabOrderInput) => {
+  const notes = generateNote(cartItems);
+  return {
+    store_id: '62f0fcbffc3f4e916f865d6a', // Hard Coded for now
+    order_number: orderNumber,
+    stash: {
+      store_id: '62f0fcbffc3f4e916f865d6a', // Hard Coded for now, must match store_id higher up
+      type: 'manual',
+      id: orderNumber,
+      notes: notes,
+      date: getCurrentDateInPST(),
+      items: cartItems.map((cartItem) => ({
+        quantity: cartItem.quantity,
+        price: cartItem.msrp,
+        type: 'item', // Item Or Kit (for Full Seat Cover bundle)
+        // lineSku: '', // In the future will need to grab the SKU Lab sku
+        // id: '' // In the future need to grab SKU Lab item id
+        // lineName: '' // In the future need to grab SKU Lab lineName
+        // lineId: '' // In the future will need to grab from SKU Lab
+      })),
+      discount: 0, // TODO: Currently no promo, but need to update later
+      shipping: 0, // TODO: Currently no shipping, but need to update later
+      financial_status: '',
+      tax: 0, // Currently no tax
+      total: convertPriceFromStripeFormat(totalMsrpPrice),
+      shipping_information: {
+        name: shippingAddress.name,
+        phone: shippingAddress.phone,
+        email: customerInfo.email,
+        company: '',
+        city: shippingAddress.address.city,
+        country: shippingAddress.address.country,
+        state: shippingAddress.address.state,
+        zip: shippingAddress.address.postal_code,
+        address: shippingAddress.address.line1,
+        address_2: shippingAddress.address.line2,
+        method: '2 day free shipping',
+      },
+      tags: ['Coverland'],
+    },
+  };
+};


### PR DESCRIPTION
It is time consuming for CSRs to create a new order whenever someone purchases a product.
We want to be able to send SKU Labs customer information to help reducing CSR workload

Important documentation here:
https://app.clickup.com/t/8688px0k2


https://app.clickup.com/t/8688qcn4c

# Test Instructions
1. Purchase an order on Coverland.com
2. Verify order is successfully purchased and you go to thank you page.
3. Verify order shows up in SKULabs
4. Verify order details are correct in SKU Labs
5. Test for both Stripe and Paypal

