### PR TITLE
Added Payment gateway to SKU Lab & Map Paypal Info to SKU Lab instead of user input

### DIFF
--- a/src/components/checkout/PayPalButtonSection.tsx
+++ b/src/components/checkout/PayPalButtonSection.tsx
@@ -202,12 +202,35 @@ export default function PayPalButtonSection() {
               }
 
               if (process.env.NEXT_PUBLIC_IS_PREVIEW !== 'PREVIEW') {
+                // Mapping it differently because sometimes Paypal info is different than what customer provides
+                // Using Paypal so we can match it with Paypal itself
+                const paypalShipping =
+                  response.data?.purchase_units[0]?.shipping;
+                const paymentSourceCustomerEmail =
+                  response.data?.payment_source?.paypal?.email_address;
+                const shippingAddressPaypalForSkuLab = {
+                  name: paypalShipping?.name?.full_name,
+                  phone: customerInfo.phoneNumber,
+                  address: {
+                    city: paypalShipping?.address?.admin_area_2,
+                    country: paypalShipping?.address?.country_code,
+                    state: paypalShipping?.address?.admin_area_1,
+                    postal_code: paypalShipping?.address?.postal_code,
+                    line1: paypalShipping?.address?.address_line_1,
+                    line2: paypalShipping?.address?.address_line_2 || '',
+                  },
+                };
+                const customerInfoPaypalForSkuLab = {
+                  email: paymentSourceCustomerEmail,
+                  phoneNumber: customerInfo.phoneNumber,
+                };
                 const skuLabOrderInput = generateSkuLabOrderInput({
                   orderNumber,
                   cartItems,
                   totalMsrpPrice,
-                  shippingAddress,
-                  customerInfo,
+                  shippingAddress: shippingAddressPaypalForSkuLab,
+                  customerInfo: customerInfoPaypalForSkuLab,
+                  paymentMethod: 'Paypal',
                 });
 
                 // SKU Labs Order Creation

--- a/src/components/checkout/Payment.tsx
+++ b/src/components/checkout/Payment.tsx
@@ -250,6 +250,7 @@ export default function Payment() {
               totalMsrpPrice: convertPriceFromStripeFormat(totalMsrpPrice),
               shippingAddress,
               customerInfo,
+              paymentMethod: "Stripe"
             });
 
             // SKU Labs Order Creation

--- a/src/lib/utils/skuLabs.ts
+++ b/src/lib/utils/skuLabs.ts
@@ -58,6 +58,7 @@ type SkuLabOrderInput = {
   totalMsrpPrice: number;
   shippingAddress: StripeAddress;
   customerInfo: CustomerInfo;
+  paymentMethod: string;
 };
 
 // 
@@ -66,7 +67,7 @@ type SkuLabOrderInput = {
  * @param cartItems 
  * @returns 
  */
-const generateNote = (cartItems: TCartItem[]) => {
+const generateNote = (cartItems: TCartItem[], paymentMethod: string) => {
   const skuNameQuantity = cartItems.map((cartItem: TCartItem) => {
     const itemName =
       `${cartItem?.year_generation || ''} ${cartItem?.make || ''} ${cartItem?.model || ''} ${
@@ -76,7 +77,7 @@ const generateNote = (cartItems: TCartItem[]) => {
       }`
         .replace(/\s+/g, ' ')
         .trim();
-    return `${cartItem.sku} ${itemName} Quantity: ${cartItem.quantity}`;
+    return `Payment Method: ${paymentMethod} ${cartItem.sku} ${itemName} Quantity: ${cartItem.quantity}`;
   });
 
   return skuNameQuantity.join('\n');
@@ -88,8 +89,9 @@ export const generateSkuLabOrderInput = ({
   totalMsrpPrice,
   shippingAddress,
   customerInfo,
+  paymentMethod
 }: SkuLabOrderInput): SkuLabOrderDTO => {
-  const notes = generateNote(cartItems);
+  const notes = generateNote(cartItems, paymentMethod);
   return {
     store_id: '62f0fcbffc3f4e916f865d6a', // Hard Coded for now
     order_number: orderNumber,


### PR DESCRIPTION
CSRs requested seeing whether it is Paypal/Stripe in SKU Lab notes
Also had a discrepancy when user typed in something different from Paypal, made it hard to find so going to send SKU Lab info from Paypal instead. 


## To Test

1. Pull code down locally
2. Remove "PREVIEW" checks
3. Go through checkout process w/ stripe, verify Stripe appears in notes in SKU Labs (ask someone)
4. Go through checkout process w/ Paypal, verify Paypal appears in notes in SKU Labs and shipping address info lines up with what was in Paypal
