### PR TITLE
Reverted paypal skulab shipping info back to customer input

### DIFF
--- a/src/components/checkout/PayPalButtonSection.tsx
+++ b/src/components/checkout/PayPalButtonSection.tsx
@@ -201,6 +201,7 @@ export default function PayPalButtonSection() {
                   },
                   body: JSON.stringify({ metaCPIEvent }),
                 });
+
                 // Track the purchase event
                 if (typeof fbq === 'function') {
                   fbq(
@@ -215,6 +216,7 @@ export default function PayPalButtonSection() {
                     { eventID }
                   );
                 }
+
                 // Microsoft Conversion API Tracking
                 if (typeof window !== 'undefined') {
                   window.uetq = window.uetq || [];
@@ -234,34 +236,12 @@ export default function PayPalButtonSection() {
                   });
                 }
 
-                // Mapping it differently because sometimes Paypal info is different than what customer provides
-                // Using Paypal so we can match it with Paypal itself
-                const paypalShipping =
-                  response.data?.purchase_units[0]?.shipping;
-                const paymentSourceCustomerEmail =
-                  response.data?.payment_source?.paypal?.email_address;
-                const shippingAddressPaypalForSkuLab = {
-                  name: paypalShipping?.name?.full_name,
-                  phone: customerInfo.phoneNumber,
-                  address: {
-                    city: paypalShipping?.address?.admin_area_2,
-                    country: paypalShipping?.address?.country_code,
-                    state: paypalShipping?.address?.admin_area_1,
-                    postal_code: paypalShipping?.address?.postal_code,
-                    line1: paypalShipping?.address?.address_line_1,
-                    line2: paypalShipping?.address?.address_line_2 || '',
-                  },
-                };
-                const customerInfoPaypalForSkuLab = {
-                  email: paymentSourceCustomerEmail,
-                  phoneNumber: customerInfo.phoneNumber,
-                };
                 const skuLabOrderInput = generateSkuLabOrderInput({
                   orderNumber,
                   cartItems,
                   totalMsrpPrice,
-                  shippingAddress: shippingAddressPaypalForSkuLab,
-                  customerInfo: customerInfoPaypalForSkuLab,
+                  shippingAddress,
+                  customerInfo,
                   paymentMethod: 'Paypal',
                 });
 
@@ -289,6 +269,7 @@ export default function PayPalButtonSection() {
                   postal_code: shippingAddress.address.postal_code || '',
                   country: shippingAddress.address.country || '',
                 };
+
                 handlePurchaseGoogleTag(
                   cartItems,
                   orderNumber,


### PR DESCRIPTION
Sometimes there's a discrepancy  between Paypal shipping info and what the customer input.

We're reverting back to sending SKU Labs the customer input, but we will save paypal shipping to admin panel for the time  being.