### PR TITLE
Updating Product Display Title to use selectedProdcut value in store

### DIFF
--- a/src/app/(main)/[productType]/components/LinkBreadcrumbs.tsx
+++ b/src/app/(main)/[productType]/components/LinkBreadcrumbs.tsx
@@ -1,13 +1,22 @@
 'use client';
+import { SeatCoverSelectionContext } from '@/contexts/SeatCoverContext';
 import useDetermineType from '@/hooks/useDetermineType';
+import useStoreContext from '@/hooks/useStoreContext';
 import { deslugify } from '@/lib/utils';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { useContext } from 'react';
+import { useStore } from 'zustand';
 
 export default function LinkBreadcrumbs() {
   const params = Object(useParams());
   const paramKeys = Object.keys(params);
   const paramValues = Object.values(params);
   const { isSeatCover } = useDetermineType();
+  const store = useStoreContext();
+  if (!store)
+    throw new Error('Missing SeatCoverSelectionContext.Provider in the tree');
+
+  const selectedProduct = useStore(store, (s) => s.selectedProduct);
 
   const getUrlFromBreadcrumbs = (index: number): string => {
     let returnString = '';
@@ -45,10 +54,15 @@ export default function LinkBreadcrumbs() {
                 className={`hover:underline ${params[key].length < 4 ? 'uppercase' : 'capitalize'} `}
               >
                 {/* Replacing hyphens with spaces (except for year_generation) */}
-                {params[key] && key === 'year'
-                  ? params[key]
-                  : // : String(params[key]).replaceAll('-', ' ')
-                    deslugify(String(params[key]))}
+
+                {key === 'productType' && selectedProduct.type}
+                {key === 'coverType' &&
+                  params[key] !== 'leather' &&
+                  'Premium Plus'}
+                {key === 'make' && selectedProduct.make}
+                {key === 'model' && selectedProduct.model}
+                {key === 'year' && params[key]}
+                {params[key] === 'leather' && 'Leather'}
               </a>
               {index != paramKeys.length - 1 && <p>/</p>}
             </div>

--- a/src/app/(main)/[productType]/components/LinkBreadcrumbs.tsx
+++ b/src/app/(main)/[productType]/components/LinkBreadcrumbs.tsx
@@ -51,7 +51,7 @@ export default function LinkBreadcrumbs() {
               <p> </p>
               <a
                 href={getUrlFromBreadcrumbs(index)}
-                className={`hover:underline ${params[key].length < 4 ? 'uppercase' : 'capitalize'} `}
+                className={`'uppercase' hover:underline`}
               >
                 {/* Replacing hyphens with spaces (except for year_generation) */}
 

--- a/src/app/(main)/[productType]/components/LinkBreadcrumbs.tsx
+++ b/src/app/(main)/[productType]/components/LinkBreadcrumbs.tsx
@@ -51,7 +51,7 @@ export default function LinkBreadcrumbs() {
               <p> </p>
               <a
                 href={getUrlFromBreadcrumbs(index)}
-                className={`'uppercase' hover:underline`}
+                className={`hover:underline`}
               >
                 {/* Replacing hyphens with spaces (except for year_generation) */}
 

--- a/src/app/(main)/[productType]/components/ProductContent.tsx
+++ b/src/app/(main)/[productType]/components/ProductContent.tsx
@@ -113,9 +113,8 @@ export function ProductContent({
         <>Waterproof Outdoor Custom-Fit {`${productType} `}</>
       ) : (
         <>
-          {make && `${deslugify(make as string)} `}
-          {model && `${deslugify(model as string)} `}
-          {`${productType} `}
+          {make && (selectedProduct.make as string)}{' '}
+          {model && (selectedProduct.model as string)} {`${productType} `}
           {' - '}
           <br />
           <>Waterproof, Outdoor, Custom-Fit</>

--- a/src/app/(main)/seat-covers/components/SeatContent.tsx
+++ b/src/app/(main)/seat-covers/components/SeatContent.tsx
@@ -52,8 +52,8 @@ export default function SeatContent({
         <div className="mt-4 flex flex-col gap-0.5 lg:mt-10">
           {/* Product Title */}
           <h2 className="text-[24px] font-[900] leading-[27px] text-[#1A1A1A] lg:text-[28px] lg:leading-[30px] ">
-            {make && `${deslugify(make as string)} `}
-            {model && `${deslugify(model as string)} `} Seat Covers -
+            {make && (selectedProduct.make as string)}{' '}
+            {model && (selectedProduct.model as string)} Seat Covers -
             <br className="max-lg:hidden" /> Custom-Fit, Fine Comfort Leather
           </h2>
           {/* Rating(s) */}

--- a/src/components/edit-vehicle/EditVehicleModal.tsx
+++ b/src/components/edit-vehicle/EditVehicleModal.tsx
@@ -50,7 +50,7 @@ export default function EditVehicleModal({
         <SheetTrigger className="flex h-full items-center justify-between text-left text-base text-[#1A1A1A]">
           <div className="my-2 border-l-2 border-l-[#C8C7C7] pl-8 pr-8">
             <p className="text-[10px] leading-[14px] ">Your Vehicle</p>
-            <p className=" text-[18px] font-[500] capitalize leading-[22px] text-[#1A1A1A]">
+            <p className=" text-[18px] font-[500] leading-[22px] text-[#1A1A1A]">
               {productName}
             </p>
             <h2 className="text-[12px] leading-[15px] text-[#8F8F8F]">

--- a/src/components/edit-vehicle/EditVehiclePopover.tsx
+++ b/src/components/edit-vehicle/EditVehiclePopover.tsx
@@ -48,7 +48,7 @@ export default function EditVehiclePopover({
           <button className="flex w-full flex-shrink cursor-pointer items-center justify-between pl-[30px]">
             <div className="flex w-full flex-col items-start justify-start">
               <p className="">Your Vehicle</p>
-              <p className="break-normal text-left text-[26px] font-[500] capitalize leading-[31px]">
+              <p className="break-normal text-left text-[26px] font-[500] leading-[31px]">
                 {productName}
               </p>
               <p className="text-[16px] leading-[22px] text-[#8F8F8F]">


### PR DESCRIPTION
The PDP product title should have the matching casing and symbols from the EditVehicleDropdown

Live:
![image](https://github.com/devwilliamy/coverland/assets/156227633/483b4524-6b2a-4e4e-bf48-912bb3dfcf59)



