### PR TITLE
Updated shipping text to say USPS or UPS

### DIFF
--- a/src/components/checkout/SavedShippingBox.tsx
+++ b/src/components/checkout/SavedShippingBox.tsx
@@ -15,7 +15,7 @@ export default function SavedShippingBox({
   return (
     <SummaryBox handleClick={handleClick}>
       <div>{shippingOptions[selectedIndex].shippingText}</div>
-      <div>{shippingOptions[selectedIndex].fedexText}</div>
+      <div>{shippingOptions[selectedIndex].shippingEstimateText}</div>
     </SummaryBox>
   );
 }

--- a/src/components/checkout/ShippingOptions.ts
+++ b/src/components/checkout/ShippingOptions.ts
@@ -2,11 +2,11 @@ export const shippingOptions = [
   {
     price: 0,
     shippingText: '$ 0.00 Free Shipping',
-    fedexText: 'FedEx Ground 1-5 Business Days',
+    shippingEstimateText: 'USPS or UPS Ground 2-5 Business Days',
   },
   // {
   //   price: 29.99,
   //   shippingText: '$29.99',
-  //   fedexText: 'FedEx 2 Day',
+  //   shippingEstimateText: 'FedEx 2 Day',
   // },
 ];

--- a/src/components/checkout/ShippingSelection.tsx
+++ b/src/components/checkout/ShippingSelection.tsx
@@ -23,7 +23,7 @@ export default function ShippingSelection() {
           className={`mb-2 cursor-pointer rounded-xl px-6 py-4 ${selectedIndex === i ? 'border-4 border-[#BE1B1B]' : 'border border-[#707070]'}`}
         >
           <div>{shippingOption?.shippingText}</div>
-          <div>{shippingOption?.fedexText}</div>
+          <div>{shippingOption?.shippingEstimateText}</div>
         </div>
       ))}
     </>


### PR DESCRIPTION
Original text had FedEx because that was in the design. We aren't using FedEx at all for shipping at the moment.  Updating shipping text to make more sense.