### PR TITLE
Fixing PDP Klarna installment image spacing 

### DIFF
--- a/src/app/(main)/[productType]/components/CircleColorSelector.tsx
+++ b/src/app/(main)/[productType]/components/CircleColorSelector.tsx
@@ -57,7 +57,7 @@ export default function CircleColorSelector() {
   return (
     <section
       id="select-color"
-      className="mt-[24px] flex h-full w-full flex-col py-1"
+      className="mt-[24px] flex h-full w-full flex-col"
     >
       <h3 className="mb-[6px] max-h-[13px] text-[16px] font-[400] leading-[14px] text-black ">
         Select Color

--- a/src/app/(main)/[productType]/components/ProductContent.tsx
+++ b/src/app/(main)/[productType]/components/ProductContent.tsx
@@ -218,7 +218,7 @@ export function ProductContent({
               ${(installmentPrice / 4).toFixed(2)}
             </b>
           </p>
-          <KlarnaIcon className="flex max-h-[30px] w-fit" />
+          <KlarnaIcon className="flex max-h-[30px] w-fit max-w-[61px]" />
           {/* <Info className="h-[17px] w-[17px] text-[#767676]" /> */}
         </div>
       </section>

--- a/src/app/(main)/[productType]/components/ProductContent.tsx
+++ b/src/app/(main)/[productType]/components/ProductContent.tsx
@@ -212,13 +212,13 @@ export function ProductContent({
           )}
         </div>
         <div className="mt-1 flex items-center gap-0.5 ">
-          <p className=" text-[14px] leading-[16px] text-[#767676] lg:text-[16px]">
+          <p className=" text-[16px] leading-[16px] text-[#767676] ">
             4 interest-free installments of{' '}
-            <b className="font-[400] text-black">
+            <b className="font-[500] text-black">
               ${(installmentPrice / 4).toFixed(2)}
             </b>
           </p>
-          <KlarnaIcon className="flex max-h-[30px] w-fit max-w-[61px]" />
+          <KlarnaIcon className="-ml-[5px] -mt-[1px] flex max-h-[30px] w-fit max-w-[61px]" />
           {/* <Info className="h-[17px] w-[17px] text-[#767676]" /> */}
         </div>
       </section>

--- a/src/app/(main)/seat-covers/components/SeatContent.tsx
+++ b/src/app/(main)/seat-covers/components/SeatContent.tsx
@@ -132,7 +132,7 @@ export default function SeatContent({
             </b>
           </p>
         )}
-        <KlarnaIcon className="flex max-h-[30px] w-fit" />
+        <KlarnaIcon className="flex max-h-[30px] w-fit max-w-[61px]" />
         {/* <Info className="h-[17px] w-[17px] text-[#767676]" /> */}
       </div>
 


### PR DESCRIPTION
Need to make the Klarna Image appear on the same line as the installments:

Also per Calvin request:
- Move Klarna 1px up and reduce the left side gap
- Installment text 14->16px 
- Installment price weight 400->500

![image](https://github.com/devwilliamy/coverland/assets/156227633/6634e28b-0103-4745-9159-467172aef36a)
