### PR TITLE
Submodel Search Params Not Refreshing Page & Adding IsComplete checks

### DIFF
--- a/src/app/(main)/seat-covers/components/SeatContent.tsx
+++ b/src/app/(main)/seat-covers/components/SeatContent.tsx
@@ -10,7 +10,7 @@ import { useStore } from 'zustand';
 import SeatCoverColorSelector from './SeatCoverColorSelector';
 import PreorderSheet from '@/components/cart/PreorderSheet';
 import { Separator } from '@/components/ui/separator';
-import { TQueryParams } from '@/utils';
+import { getCompleteSelectionData, TQueryParams } from '@/utils';
 import AddToCart from '@/components/cart/AddToCart';
 import EditVehicle from '@/components/edit-vehicle/EditVehicle';
 import FreeDetails from '../../[productType]/components/FreeDetails';
@@ -27,11 +27,17 @@ export default function SeatContent({
 }: {
   searchParams: TQueryParams;
 }) {
-  const params = useParams<TPathParams>();
-  const isFinalSelection = params?.year;
   const store = useContext(SeatCoverSelectionContext);
   if (!store)
     throw new Error('Missing SeatCoverSelectionContext.Provider in the tree');
+  const modelData = useStore(store, (s) => s.modelData);
+
+  const {
+    completeSelectionState: { isComplete },
+  } = getCompleteSelectionData({
+    data: modelData,
+  });
+
   const router = useRouter();
 
   const selectedProduct = useStore(store, (s) => s.selectedProduct);
@@ -44,7 +50,6 @@ export default function SeatContent({
   const [discountPercent, setDiscountPercent] = useState<number | null>(50);
   const [newMSRP, setNewMSRP] = useState<number | null>(selectedProduct.msrp);
   const [loading, setLoading] = useState(false);
-
 
   useEffect(() => {
     setLoading(true);
@@ -143,11 +148,9 @@ export default function SeatContent({
         {/* <Info className="h-[17px] w-[17px] text-[#767676]" /> */}
       </div>
 
-      {!!isFinalSelection ? (
-        <SeatCoverSelection />
-      ) : null}
-      <SeatCoverColorSelector isFinalSelection={isFinalSelection} />
-      <FreeDetails selectedProduct={selectedProduct} />
+      {!!isComplete ? <SeatCoverSelection /> : null}
+      <SeatCoverColorSelector />
+      <FreeDetails />
       {/* <CompatibleVehiclesTrigger /> */}
       <div className="lg:py-4"></div>
       <div className="lg:hidden">

--- a/src/app/(main)/seat-covers/components/SeatCoverColorSelector.tsx
+++ b/src/app/(main)/seat-covers/components/SeatCoverColorSelector.tsx
@@ -8,6 +8,7 @@ import CircleGray from '@/images/PDP/Product-Details-Redesign-2/seat-covers/cove
 import CircleBeige from '@/images/PDP/Product-Details-Redesign-2/seat-covers/cover-colors/beige/seat-circle-beige.webp';
 import { TSeatCoverDataDB } from '@/lib/db/seat-covers';
 import { isFullSet } from '@/lib/utils';
+import { getCompleteSelectionData } from '@/utils';
 
 const iconMap: Record<string, StaticImageData> = {
   'Solid Black with Red Stitching': CircleBlackRed,
@@ -16,11 +17,7 @@ const iconMap: Record<string, StaticImageData> = {
   Beige: CircleBeige,
 };
 
-export default function SeatCoverColorSelector({
-  isFinalSelection,
-}: {
-  isFinalSelection: unknown;
-}) {
+export default function SeatCoverColorSelector() {
   const store = useContext(SeatCoverSelectionContext);
   if (!store)
     throw new Error('Missing SeatCoverSelectionContext.Provider in the tree');
@@ -32,6 +29,12 @@ export default function SeatCoverColorSelector({
   const selectedColor = useStore(store, (state) => state.selectedColor);
   const availableColors = useStore(store, (s) => s.availableColors);
   const selectedSetDisplay = useStore(store, (s) => s.selectedSetDisplay);
+
+  const {
+    completeSelectionState: { isComplete },
+  } = getCompleteSelectionData({
+    data: modelData,
+  });
 
   const showColors = [
     {
@@ -102,7 +105,7 @@ export default function SeatCoverColorSelector({
   return (
     <section
       id="select-color"
-      className={` ${!isFinalSelection ? 'mb-[30px] mt-[24px]' : 'mb-[40px]'} py-1}  ml-[4px]  flex w-full flex-col`}
+      className={` ${!isComplete ? 'mb-[30px] mt-[24px]' : 'mb-[40px]'} py-1}  ml-[4px]  flex w-full flex-col`}
     >
       <div className="mb-[6px] flex flex-row content-center justify-start align-middle leading-[14px]">
         <h3 className=" max-h-[13px] pl-[3px] text-[16px] font-[400] text-black ">
@@ -113,7 +116,7 @@ export default function SeatCoverColorSelector({
             {allOutOfStock(getModelDataBySet)
               ? 'Out of Stock'
               : !availableColors.includes(selectedColor.toLowerCase()) ||
-                  selectedProduct.preorder && isFinalSelection // only displays Pre-Order if we are in a final selection product page such as seat-covers/leather/make/model/year and the selected product has preorder set to true
+                  (selectedProduct.preorder && isComplete) // only displays Pre-Order if we are in a final selection product page such as seat-covers/leather/make/model/year and the selected product has preorder set to true
                 ? `${selectedColor.charAt(0).toUpperCase()}${selectedColor.slice(1)} (Pre-Order)`
                 : selectedColor.charAt(0).toUpperCase() +
                   selectedColor.slice(1)}

--- a/src/components/PDP/EditVehicleDropdown.tsx
+++ b/src/components/PDP/EditVehicleDropdown.tsx
@@ -171,7 +171,12 @@ export default function EditVehicleDropdown({
       return;
     }
     // refreshRoute('/');
-    router.push(url);
+    if (submodel1 || submodel2) {
+      window.location.href = url;
+    } else {
+      router.push(url);
+    }
+
     closePopover();
   };
 

--- a/src/components/cart/AddToCart.tsx
+++ b/src/components/cart/AddToCart.tsx
@@ -53,7 +53,6 @@ export default function AddToCart({
   const initalLoadingState = false;
   const [isLoading, setIsLoading] = useState<boolean>(initalLoadingState);
   const [selectSeatOpen, setSelectSeatOpen] = useState<boolean>(false);
-  const isFinalSelection = params?.year;
 
   const {
     completeSelectionState: { isComplete },

--- a/src/components/cart/AddToCartButton.tsx
+++ b/src/components/cart/AddToCartButton.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
-import { TPathParams } from '../../utils';
-import { useParams } from 'next/navigation';
+import { getCompleteSelectionData } from '../../utils';
 import CarMagnify from '@/components/icons/CarMagnify';
 import { FaSpinner } from 'react-icons/fa';
+import useStoreContext from '@/hooks/useStoreContext';
+import { useStore } from 'zustand';
 
 type AddToCartButtonProps = {
   handleAddToCartClicked: () => void;
@@ -17,8 +18,16 @@ export default function AddToCartButton({
   handleAddToCartClicked,
   isLoading,
 }: AddToCartButtonProps) {
-  const params = useParams<TPathParams>();
-  const isFinalSelection = params?.year;
+  const store = useStoreContext();
+  if (!store) throw new Error('Missing Provider in the tree');
+
+  const modelData = useStore(store, (s) => s.modelData);
+
+  const {
+    completeSelectionState: { isComplete },
+  } = getCompleteSelectionData({
+    data: modelData,
+  });
   const [nonFinalButtonText, setNonFinalButtonText] = useState(
     'Find your Custom-Cover'
   );
@@ -34,7 +43,7 @@ export default function AddToCartButton({
       <div
         className="flex gap-[10px]"
         style={
-          !isFinalSelection
+          !isComplete
             ? {
                 animation: `blink ${blinkTime}s cubic-bezier(0,-${blinkVel},1,${blinkVel}) infinite`,
               }
@@ -60,7 +69,11 @@ export default function AddToCartButton({
           )
         )}
         <p>
-          {!isFinalSelection ? nonFinalButtonText : preorder? 'Pre-order & Save Big' : 'Add To Cart'}
+          {!isComplete
+            ? nonFinalButtonText
+            : preorder
+              ? 'Pre-order & Save Big'
+              : 'Add To Cart'}
         </p>
       </div>
     </Button>

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -16,8 +16,8 @@ const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY ?? '';
 
 const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
-// export type TInitialProductDataDB = Tables<'Products'>;
-export type TSeatCoverDataDB = Tables<'Products_preorder_duplicate'>;
+export type TInitialProductDataDB = Tables<'Products'>;
+export type TSeatCoverDataDB = Tables<'Products'>;
 
 //If the table you want to access isn't listed in TableRow,
 //generate new types in the Supabase dashboard to update

--- a/src/lib/db/seat-covers/index.ts
+++ b/src/lib/db/seat-covers/index.ts
@@ -5,7 +5,7 @@ import { slugToCoverType } from '@/lib/constants';
 import { slugify } from '@/lib/utils';
 
 // export type TSeatCoverDataDB = Tables<'Products'>;
-export type TSeatCoverDataDB = Tables<'Products_preorder_duplicate'>;
+export type TSeatCoverDataDB = Tables<'Products'>;
 
 // URL: supabase.com/dashboard/project/<project_id>/api?pages=tables-intro
 //If the table you want to access isn't listed in TableRow,

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -1634,7 +1634,7 @@ export type Database = {
             foreignKeyName: "orderItems_table_duplicate_product_id_fkey"
             columns: ["product_id"]
             isOneToOne: false
-            referencedRelation: "Products"
+            referencedRelation: "Products_20240617_old"
             referencedColumns: ["id"]
           },
         ]
@@ -1730,7 +1730,7 @@ export type Database = {
             foreignKeyName: "orderItems_table_TEST_duplicate_product_id_fkey"
             columns: ["product_id"]
             isOneToOne: false
-            referencedRelation: "Products"
+            referencedRelation: "Products_20240617_old"
             referencedColumns: ["id"]
           },
         ]
@@ -1767,6 +1767,9 @@ export type Database = {
           model_slug: string | null
           msrp: number | null
           parent_generation: string | null
+          preorder: boolean | null
+          preorder_date: string | null
+          preorder_discount: number | null
           price: number | null
           product: string | null
           product_video_360: string | null
@@ -1796,6 +1799,9 @@ export type Database = {
           model_slug?: string | null
           msrp?: number | null
           parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
           price?: number | null
           product?: string | null
           product_video_360?: string | null
@@ -1825,6 +1831,9 @@ export type Database = {
           model_slug?: string | null
           msrp?: number | null
           parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
           price?: number | null
           product?: string | null
           product_video_360?: string | null
@@ -2002,6 +2011,195 @@ export type Database = {
           model_slug?: string | null
           msrp?: number | null
           parent_generation?: string | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Relationships: []
+      }
+      Products_20240617_old: {
+        Row: {
+          banner: string | null
+          display_color: string | null
+          display_id: string | null
+          display_set: string | null
+          feature: string | null
+          id: number
+          make: string | null
+          make_slug: string | null
+          model: string | null
+          model_slug: string | null
+          msrp: number | null
+          parent_generation: string | null
+          price: number | null
+          product: string | null
+          product_video_360: string | null
+          product_video_carousel: string | null
+          product_video_carousel_thumbnail: string | null
+          product_video_zoom: string | null
+          quantity: string | null
+          sku: string | null
+          "skulabs SKU": string | null
+          submodel1: string | null
+          submodel2: string | null
+          submodel3: string | null
+          type: string | null
+          year_generation: string | null
+          year_options: string | null
+        }
+        Insert: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id: number
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Update: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id?: number
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Relationships: []
+      }
+      Products_20240709_backup: {
+        Row: {
+          banner: string | null
+          display_color: string | null
+          display_id: string | null
+          display_set: string | null
+          feature: string | null
+          id: number
+          make: string | null
+          make_slug: string | null
+          model: string | null
+          model_slug: string | null
+          msrp: number | null
+          parent_generation: string | null
+          preorder: boolean | null
+          preorder_date: string | null
+          preorder_discount: number | null
+          price: number | null
+          product: string | null
+          product_video_360: string | null
+          product_video_carousel: string | null
+          product_video_carousel_thumbnail: string | null
+          product_video_zoom: string | null
+          quantity: string | null
+          sku: string | null
+          "skulabs SKU": string | null
+          submodel1: string | null
+          submodel2: string | null
+          submodel3: string | null
+          type: string | null
+          year_generation: string | null
+          year_options: string | null
+        }
+        Insert: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id: number
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Update: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id?: number
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
           price?: number | null
           product?: string | null
           product_video_360?: string | null
@@ -2209,6 +2407,105 @@ export type Database = {
         }
         Relationships: []
       }
+      Products_seat_covers_front_seats: {
+        Row: {
+          banner: string | null
+          display_color: string | null
+          display_id: string | null
+          display_set: string | null
+          feature: string | null
+          id: number | null
+          make: string | null
+          make_slug: string | null
+          model: string | null
+          model_slug: string | null
+          msrp: number | null
+          parent_generation: string | null
+          preorder: boolean | null
+          preorder_date: string | null
+          preorder_discount: number | null
+          price: number | null
+          product: string | null
+          product_video_360: string | null
+          product_video_carousel: string | null
+          product_video_carousel_thumbnail: string | null
+          product_video_zoom: string | null
+          quantity: string | null
+          sku: string | null
+          "skulabs SKU": string | null
+          submodel1: string | null
+          submodel2: string | null
+          submodel3: string | null
+          type: string | null
+          year_generation: string | null
+          year_options: string | null
+        }
+        Insert: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id?: number | null
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Update: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id?: number | null
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Relationships: []
+      }
       relations_product: {
         Row: {
           created_at: string | null
@@ -2242,35 +2539,35 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "relations_product_20240617_make_id_fkey"
+            foreignKeyName: "relations_product_20240709_old_make_id_fkey"
             columns: ["make_id"]
             isOneToOne: false
             referencedRelation: "Make"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "relations_product_20240617_model_id_fkey"
+            foreignKeyName: "relations_product_20240709_old_model_id_fkey"
             columns: ["model_id"]
             isOneToOne: false
             referencedRelation: "Model"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "relations_product_20240617_product_id_fkey"
+            foreignKeyName: "relations_product_20240709_old_product_id_fkey"
             columns: ["product_id"]
             isOneToOne: false
             referencedRelation: "Products"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "relations_product_20240617_type_id_fkey"
+            foreignKeyName: "relations_product_20240709_old_type_id_fkey"
             columns: ["type_id"]
             isOneToOne: false
             referencedRelation: "Type"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "relations_product_20240617_year_id_fkey"
+            foreignKeyName: "relations_product_20240709_old_year_id_fkey"
             columns: ["year_id"]
             isOneToOne: false
             referencedRelation: "Years"
@@ -2379,6 +2676,144 @@ export type Database = {
           year_id?: number | null
         }
         Relationships: []
+      }
+      relations_product_20240617_old: {
+        Row: {
+          created_at: string | null
+          id: number
+          make_id: number
+          model_id: number
+          product_id: number
+          type_id: number
+          updated_at: string | null
+          year_id: number
+        }
+        Insert: {
+          created_at?: string | null
+          id?: number
+          make_id: number
+          model_id: number
+          product_id: number
+          type_id: number
+          updated_at?: string | null
+          year_id: number
+        }
+        Update: {
+          created_at?: string | null
+          id?: number
+          make_id?: number
+          model_id?: number
+          product_id?: number
+          type_id?: number
+          updated_at?: string | null
+          year_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "relations_product_20240617_make_id_fkey"
+            columns: ["make_id"]
+            isOneToOne: false
+            referencedRelation: "Make"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240617_model_id_fkey"
+            columns: ["model_id"]
+            isOneToOne: false
+            referencedRelation: "Model"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240617_old_product_id_fkey"
+            columns: ["product_id"]
+            isOneToOne: false
+            referencedRelation: "Products_20240617_old"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240617_type_id_fkey"
+            columns: ["type_id"]
+            isOneToOne: false
+            referencedRelation: "Type"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240617_year_id_fkey"
+            columns: ["year_id"]
+            isOneToOne: false
+            referencedRelation: "Years"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      relations_product_20240709_backup: {
+        Row: {
+          created_at: string | null
+          id: number
+          make_id: number
+          model_id: number
+          product_id: number
+          type_id: number
+          updated_at: string | null
+          year_id: number
+        }
+        Insert: {
+          created_at?: string | null
+          id?: number
+          make_id: number
+          model_id: number
+          product_id: number
+          type_id: number
+          updated_at?: string | null
+          year_id: number
+        }
+        Update: {
+          created_at?: string | null
+          id?: number
+          make_id?: number
+          model_id?: number
+          product_id?: number
+          type_id?: number
+          updated_at?: string | null
+          year_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "relations_product_20240709_backup_make_id_fkey"
+            columns: ["make_id"]
+            isOneToOne: false
+            referencedRelation: "Make"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240709_backup_model_id_fkey"
+            columns: ["model_id"]
+            isOneToOne: false
+            referencedRelation: "Model"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240709_backup_product_id_fkey"
+            columns: ["product_id"]
+            isOneToOne: false
+            referencedRelation: "Products"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240709_backup_type_id_fkey"
+            columns: ["type_id"]
+            isOneToOne: false
+            referencedRelation: "Type"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relations_product_20240709_backup_year_id_fkey"
+            columns: ["year_id"]
+            isOneToOne: false
+            referencedRelation: "Years"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       reviews_car_covers: {
         Row: {
@@ -2698,6 +3133,207 @@ export type Database = {
         }
         Relationships: []
       }
+      seat_covers_back_20240710: {
+        Row: {
+          banner: string | null
+          display_color: string | null
+          display_id: string | null
+          display_set: string | null
+          feature: string | null
+          "full set SKU": string | null
+          id: number | null
+          make: string | null
+          make_slug: string | null
+          model: string | null
+          model_slug: string | null
+          msrp: number | null
+          parent_generation: string | null
+          preorder: boolean | null
+          preorder_date: string | null
+          preorder_discount: number | null
+          price: number | null
+          product: string | null
+          product_video_360: string | null
+          product_video_carousel: string | null
+          product_video_carousel_thumbnail: string | null
+          product_video_zoom: string | null
+          quantity: string | null
+          sku: string | null
+          "skulabs sku": string | null
+          submodel1: string | null
+          submodel2: string | null
+          submodel3: string | null
+          type: string | null
+          year_generation: string | null
+          year_options: string | null
+        }
+        Insert: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          "full set SKU"?: string | null
+          id?: number | null
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs sku"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Update: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          "full set SKU"?: string | null
+          id?: number | null
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs sku"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Relationships: []
+      }
+      seat_covers_front_20240709: {
+        Row: {
+          banner: string | null
+          display_color: string | null
+          display_id: string | null
+          display_set: string | null
+          feature: string | null
+          id: number
+          make: string | null
+          make_slug: string | null
+          model: string | null
+          model_slug: string | null
+          msrp: number | null
+          parent_generation: string | null
+          preorder: boolean | null
+          preorder_date: string | null
+          preorder_discount: number | null
+          price: number | null
+          product: string | null
+          product_video_360: string | null
+          product_video_carousel: string | null
+          product_video_carousel_thumbnail: string | null
+          product_video_zoom: string | null
+          quantity: string | null
+          sku: string | null
+          "skulabs sku": string | null
+          submodel1: string | null
+          submodel2: string | null
+          submodel3: string | null
+          type: string | null
+          year_generation: string | null
+          year_options: string | null
+        }
+        Insert: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id: number
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs sku"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Update: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id?: number
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs sku"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Relationships: []
+      }
       seat_covers_year_options: {
         Row: {
           id: number
@@ -2711,6 +3347,105 @@ export type Database = {
         }
         Update: {
           id?: number
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Relationships: []
+      }
+      temp_import: {
+        Row: {
+          banner: string | null
+          display_color: string | null
+          display_id: string | null
+          display_set: string | null
+          feature: string | null
+          id: number | null
+          make: string | null
+          make_slug: string | null
+          model: string | null
+          model_slug: string | null
+          msrp: number | null
+          parent_generation: string | null
+          preorder: boolean | null
+          preorder_date: string | null
+          preorder_discount: number | null
+          price: number | null
+          product: string | null
+          product_video_360: string | null
+          product_video_carousel: string | null
+          product_video_carousel_thumbnail: string | null
+          product_video_zoom: string | null
+          quantity: string | null
+          sku: string | null
+          "skulabs SKU": string | null
+          submodel1: string | null
+          submodel2: string | null
+          submodel3: string | null
+          type: string | null
+          year_generation: string | null
+          year_options: string | null
+        }
+        Insert: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id?: number | null
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
+          year_generation?: string | null
+          year_options?: string | null
+        }
+        Update: {
+          banner?: string | null
+          display_color?: string | null
+          display_id?: string | null
+          display_set?: string | null
+          feature?: string | null
+          id?: number | null
+          make?: string | null
+          make_slug?: string | null
+          model?: string | null
+          model_slug?: string | null
+          msrp?: number | null
+          parent_generation?: string | null
+          preorder?: boolean | null
+          preorder_date?: string | null
+          preorder_discount?: number | null
+          price?: number | null
+          product?: string | null
+          product_video_360?: string | null
+          product_video_carousel?: string | null
+          product_video_carousel_thumbnail?: string | null
+          product_video_zoom?: string | null
+          quantity?: string | null
+          sku?: string | null
+          "skulabs SKU"?: string | null
+          submodel1?: string | null
+          submodel2?: string | null
+          submodel3?: string | null
+          type?: string | null
           year_generation?: string | null
           year_options?: string | null
         }
@@ -3385,6 +4120,81 @@ export type Database = {
           model_slug: string
           year_options: string
           display_set: string
+          preorder: boolean
+          preorder_date: string
+          preorder_discount: number
+        }[]
+      }
+      get_seat_cover_products_sorted_by_color_preorder_20240709: {
+        Args: {
+          p_type?: string
+          p_cover?: string
+          p_make?: string
+          p_model?: string
+          p_year?: string
+          p_submodel?: string
+          p_submodel2?: string
+          p_submodel3?: string
+        }
+        Returns: {
+          sku: string
+          type: string
+          make: string
+          model: string
+          year_generation: string
+          parent_generation: string
+          submodel1: string
+          submodel2: string
+          submodel3: string
+          product: string
+          display_color: string
+          msrp: number
+          price: number
+          quantity: string
+          display_id: string
+          make_slug: string
+          model_slug: string
+          year_options: string
+          display_set: string
+          preorder: boolean
+          preorder_date: string
+          preorder_discount: number
+        }[]
+      }
+      get_seat_cover_products_sorted_by_color_preview: {
+        Args: {
+          p_type?: string
+          p_cover?: string
+          p_make?: string
+          p_model?: string
+          p_year?: string
+          p_submodel?: string
+          p_submodel2?: string
+          p_submodel3?: string
+        }
+        Returns: {
+          sku: string
+          type: string
+          make: string
+          model: string
+          year_generation: string
+          parent_generation: string
+          submodel1: string
+          submodel2: string
+          submodel3: string
+          product: string
+          display_color: string
+          msrp: number
+          price: number
+          quantity: string
+          display_id: string
+          make_slug: string
+          model_slug: string
+          year_options: string
+          display_set: string
+          preorder: boolean
+          preorder_date: string
+          preorder_discount: number
         }[]
       }
       get_statement_timeout: {


### PR DESCRIPTION
Unfortunately two changes in this PR I should have made the other one a different PR

https://app.clickup.com/t/86889zcb1

## Change 1: Submodel Search Params Reload
When on an incomplete year page or on a submodel/submodel2 page, when you try to edit the vehicle and use the same type, make, model, and year parameters, the selected product won't update.

This is caused by Next.js thinking there are certain components that just use the search params and just does a soft reload. 

In an ideal world, this is the behavior we want and what should happen is that `selectedProduct` and `modelData` get updated depending on the submodel search params. I think the steps to do this is we have to keep a copy of the initial model data because we filter down on it based on submodel. If a search param is added in EditVehicleDropdown, then we just need to setSelectedProduct and setModelData based on it. If we change to another submodel, then we take the initialModelData and setModelData based on the selected submodel

However, for speed, I'm forcing a full reload of the page when submodel/submodel2 is added to ensure when a submodel is selected the proper selectedProduct is updated.

## How to Test

It is important that type, make, model, year are the SAME when making your selection. If any type, make, model, year is different, Next will detect a change in the URL and actually refresh the page, which is not the issue.

(year just needs to be in the same parent_generation range)

### Starting from year page -> submodel
- Go to an incomplete year page (find something with a submodel, remove the submodel from URL and just be on the year page)
- Use edit vehicle / car selector to fully select the car (ensure type, make, model, year are the same)
- Add to cart
- Verify the selected product is correct
- Attempt with not just the default color
- Repeat for car-cover/seat-cover whichever one you didn't do

### Changing between different submodels
- Go to a submodel page
- Use edit vehicle to change submodels (ensure type, make, model, year are the same)
- Add to cart
- Verify the selected product is correct
- Attempt with not just the default color
- Repeat for car-cover/seat-cover whichever one you didn't do


## Known Issue
Page looks like it reloads twice which I think was something we didn't want before, but it's better than nothing

## Change 2: Add to Cart / Preorder showing too early

The Add To Cart button would show the wrong text on the year page when selection is incomplete. 
I updated the code to check if the selection is complete

## How to Test
- Test with a selection w/o submodels
- Test with selection w/ submodel
- Test with selection w/ submodel2

Things to look out for:
- If not complete, shouldn't say preorder, and shipping details shouldn't say shipped when restocked
- Should say "Find your customer cover" or what not on incomplete pages
- Ensure you're able to add to cart on complete pages
