### PR TITLE
John/preview remove quantity based discounts

### DIFF
--- a/src/app/(main)/[productType]/components/ProductContent.tsx
+++ b/src/app/(main)/[productType]/components/ProductContent.tsx
@@ -16,9 +16,7 @@ import CircleColorSelector from './CircleColorSelector';
 import ReviewsTextTrigger from './ReviewsTextTrigger';
 import installments from '@/images/PDP/Product-Details-Redesign-2/paypal-installments.webp';
 import KlarnaIcon from '@/components/icons/KlarnaIcon';
-import Image from 'next/image';
 import useDetermineType from '@/hooks/useDetermineType';
-import ReactPlayer from 'react-player';
 export function ProductContent({
   searchParams,
 }: {

--- a/src/app/(main)/[productType]/components/ProductContent.tsx
+++ b/src/app/(main)/[productType]/components/ProductContent.tsx
@@ -9,7 +9,7 @@ import { compareRawStrings, deslugify } from '@/lib/utils';
 
 import { useStore } from 'zustand';
 import { useCartContext } from '@/providers/CartProvider';
-import { IProductData, TQueryParams, getCompleteSelectionData } from '@/utils';
+import { TQueryParams, getCompleteSelectionData } from '@/utils';
 import FreeDetails from './FreeDetails';
 import AddToCart from '@/components/cart/AddToCart';
 import CircleColorSelector from './CircleColorSelector';
@@ -19,15 +19,6 @@ import KlarnaIcon from '@/components/icons/KlarnaIcon';
 import Image from 'next/image';
 import useDetermineType from '@/hooks/useDetermineType';
 import ReactPlayer from 'react-player';
-import { set } from 'zod';
-import {
-  DISCOUNT_25_LOWER_BOUND,
-  DISCOUNT_25_UPPER_BOUND,
-  NO_DISCOUNT_LOWER_BOUND,
-  NO_DISCOUNT_UPPER_BOUND,
-} from '@/lib/constants';
-import { TCartItem } from '@/lib/cart/useCart';
-import { handleCheckLowQuantity } from '@/lib/utils/calculations';
 export function ProductContent({
   searchParams,
 }: {
@@ -103,29 +94,11 @@ export function ProductContent({
   }
 
   const defaultPrice: number = defaultMSRP * 2;
-  const priceMinus5Cents = defaultMSRP - 0.05;
-  const [discountPercent, setDiscountPercent] = useState<number | null>(50);
-  const [newMSRP, setNewMSRP] = useState<number | null>(0);
-
-  useEffect(() => {
-    const checkLowQuantity = async () => {
-      const {
-        discountPercent: incomingDiscountPercent,
-        newMSRP: incomingMSRP,
-      } = handleCheckLowQuantity(cartProduct as IProductData);
-      setDiscountPercent(incomingDiscountPercent);
-      setNewMSRP(incomingMSRP);
-    };
-    checkLowQuantity();
-  }, [cartProduct]);
+  const isStandardPrice = isStandardType ? defaultMSRP : defaultMSRP - 0.05;
 
   const handleAddToCart = () => {
     if (!cartProduct) return;
     setAddToCartOpen(true);
-
-    if (newMSRP !== 0) {
-      return addToCart({ ...cartProduct, msrp: newMSRP, quantity: 1 });
-    }
 
     return addToCart({ ...cartProduct, quantity: 1 });
   };
@@ -151,19 +124,7 @@ export function ProductContent({
       )}
     </h1>
   );
-  const installmentPrice = newMSRP && newMSRP !== 0 ? newMSRP : defaultMSRP;
-  const getFormattedMSRP = () => {
-    const num = Number(
-      isComplete
-        ? newMSRP
-          ? newMSRP
-          : `${Number(cartProduct?.msrp)}`
-        : priceMinus5Cents
-    );
 
-    const formattedMSRP = String(num).includes('.5') ? num.toFixed(2) : num;
-    return formattedMSRP;
-  };
   return (
     <>
       <div className="grid grid-cols-1 lg:mt-[60px]">
@@ -197,8 +158,10 @@ export function ProductContent({
           {isComplete ? '' : 'From'}
         </p>
         <div className=" flex  items-end gap-[9px]   text-center text-[28px] font-[900]  lg:text-[32px] lg:leading-[37.5px] ">
-          <div className="leading-[20px]">${getFormattedMSRP()}</div>
-          {selectedProduct?.price && discountPercent && (
+          <div className="leading-[20px]">
+            ${isComplete ? `${Number(selectedProduct?.msrp)}` : isStandardPrice}
+          </div>
+          {selectedProduct?.price && (
             <div className="flex gap-1.5 pb-[1px] text-[22px] font-[400] leading-[14px] text-[#BE1B1B] lg:text-[22px] ">
               <span className=" text-[#BEBEBE] line-through">
                 $
@@ -206,16 +169,14 @@ export function ProductContent({
                   ? `${Number(selectedProduct?.price)}`
                   : defaultPrice}
               </span>
-              <p>(-{discountPercent}%)</p>
+              <p>(-50%)</p>
             </div>
           )}
         </div>
         <div className="mt-1 flex items-center gap-0.5 ">
           <p className=" text-[16px] leading-[16px] text-[#767676] ">
             4 interest-free installments of{' '}
-            <b className="font-[500] text-black">
-              ${(installmentPrice / 4).toFixed(2)}
-            </b>
+            <b className="font-[400] text-black">${defaultMSRP / 4 - 0.01}</b>
           </p>
           <KlarnaIcon className="-ml-[5px] -mt-[1px] flex max-h-[30px] w-fit max-w-[61px]" />
           {/* <Info className="h-[17px] w-[17px] text-[#767676]" /> */}
@@ -232,7 +193,7 @@ export function ProductContent({
       </div>
       <Separator className="mt-[36px] " />
       <Suspense>
-        <FreeDetails />
+        <FreeDetails selectedProduct={selectedProduct} />
       </Suspense>
       <div className="lg:py-4"></div>
       <AddToCart

--- a/src/app/(main)/seat-covers/components/SeatContent.tsx
+++ b/src/app/(main)/seat-covers/components/SeatContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Image from 'next/image';
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext } from 'react';
 import installments from '@/images/PDP/Product-Details-Redesign-2/paypal-installments.webp';
 import { Rating } from '@mui/material';
 import { useCartContext } from '@/providers/CartProvider';
@@ -88,7 +88,7 @@ export default function SeatContent({
         </div>
       </div>
       <div className=" flex items-end  gap-[9px] pt-[34px]   text-center text-[28px] font-[900]  lg:text-[32px] lg:leading-[37.5px] ">
-      <div className="leading-[20px]">${selectedProduct.msrp}</div>
+        <div className="leading-[20px]">${selectedProduct.msrp}</div>
         <div className="flex gap-1.5 pb-[1px] text-[22px] font-[400] leading-[14px] text-[#BE1B1B] lg:text-[22px] ">
           <span className=" text-[#BEBEBE] line-through">
             ${selectedProduct.price}
@@ -97,7 +97,7 @@ export default function SeatContent({
         </div>
       </div>
       <div className="pb-4.5 mt-[15px] flex items-center gap-0.5">
-      <p className="mb-[4px] text-[14px] leading-[16px] text-[#767676] lg:text-[16px]">
+        <p className="mb-[4px] text-[14px] leading-[16px] text-[#767676] lg:text-[16px]">
           4 interest-free installments of{' '}
           <b className="font-[400] text-black">
             ${((selectedProduct.price || 1) / 8 - 0.01).toFixed(2)}

--- a/src/app/(main)/seat-covers/components/SeatContent.tsx
+++ b/src/app/(main)/seat-covers/components/SeatContent.tsx
@@ -37,37 +37,11 @@ export default function SeatContent({
   const selectedProduct = useStore(store, (s) => s.selectedProduct);
   const [addToCartOpen, setAddToCartOpen] = useState<boolean>(false);
   const { addToCart } = useCartContext();
-  const [coverPrice, setCoverPrice] = useState(320);
 
   const { make, model } = useDetermineType();
 
-  const [discountPercent, setDiscountPercent] = useState<number | null>(50);
-  const [newMSRP, setNewMSRP] = useState<number | null>(selectedProduct.msrp);
-  const [loading, setLoading] = useState(false);
-
-
-  useEffect(() => {
-    setLoading(true);
-    const checkLowQuantity = async () => {
-      const {
-        discountPercent: incomingDiscountPercent,
-        newMSRP: incomingMSRP,
-      } = handleCheckLowQuantity(selectedProduct as TSeatCoverDataDB);
-      setDiscountPercent(incomingDiscountPercent);
-      setNewMSRP(incomingMSRP);
-    };
-    checkLowQuantity();
-
-    setLoading(false);
-  }, [selectedProduct]);
   const handleAddToCart = () => {
-    // if (!cartProduct) return; I commented this out, cartProduct is undefined
-
-    if (newMSRP !== 0) {
-      addToCart({ ...selectedProduct, msrp: newMSRP, quantity: 1 });
-    } else {
-      addToCart({ ...selectedProduct, quantity: 1 });
-    }
+    addToCart({ ...selectedProduct, quantity: 1 });
 
     if (selectedProduct.preorder) {
       setAddToCartOpen(true);
@@ -76,12 +50,6 @@ export default function SeatContent({
       router.push('/checkout');
     }
   };
-
-  if (!selectedProduct.price) {
-    setLoading(false);
-    throw new Error('No Selected Product Price in store');
-  }
-  const installmentPrice = newMSRP !== 0 ? newMSRP : selectedProduct.msrp;
 
   return (
     <section className="flex w-full flex-col max-lg:px-4 max-lg:pt-4 lg:sticky lg:top-8 lg:w-1/2">
@@ -120,32 +88,26 @@ export default function SeatContent({
         </div>
       </div>
       <div className=" flex items-end  gap-[9px] pt-[34px]   text-center text-[28px] font-[900]  lg:text-[32px] lg:leading-[37.5px] ">
-        <div className="leading-[20px]">${newMSRP}</div>
-        {discountPercent && (
-          <div className="flex gap-1.5 pb-[1px] text-[22px] font-[400] leading-[14px] text-[#BE1B1B] lg:text-[22px] ">
-            <span className=" text-[#BEBEBE] line-through">
-              ${selectedProduct.price}
-            </span>
-            <p>(-{discountPercent}%)</p>
-          </div>
-        )}
+      <div className="leading-[20px]">${selectedProduct.msrp}</div>
+        <div className="flex gap-1.5 pb-[1px] text-[22px] font-[400] leading-[14px] text-[#BE1B1B] lg:text-[22px] ">
+          <span className=" text-[#BEBEBE] line-through">
+            ${selectedProduct.price}
+          </span>
+          <p>(-50%)</p>
+        </div>
       </div>
       <div className="pb-4.5 mt-[15px] flex items-center gap-0.5">
-        {installmentPrice && (
-          <p className="text-[14px] leading-[16px] text-[#767676] lg:text-[16px]">
-            4 interest-free installments of{' '}
-            <b className="font-[400] text-black">
-              ${(installmentPrice / 4).toFixed(2)}
-            </b>
-          </p>
-        )}
+      <p className="mb-[4px] text-[14px] leading-[16px] text-[#767676] lg:text-[16px]">
+          4 interest-free installments of{' '}
+          <b className="font-[400] text-black">
+            ${((selectedProduct.price || 1) / 8 - 0.01).toFixed(2)}
+          </b>
+        </p>
         <KlarnaIcon className="flex max-h-[30px] w-fit max-w-[61px]" />
         {/* <Info className="h-[17px] w-[17px] text-[#767676]" /> */}
       </div>
 
-      {!!isFinalSelection ? (
-        <SeatCoverSelection />
-      ) : null}
+      {!!isFinalSelection ? <SeatCoverSelection /> : null}
       <SeatCoverColorSelector isFinalSelection={isFinalSelection} />
       <FreeDetails selectedProduct={selectedProduct} />
       {/* <CompatibleVehiclesTrigger /> */}
@@ -155,7 +117,6 @@ export default function SeatContent({
           selectedProduct={selectedProduct}
           handleAddToCart={handleAddToCart}
           searchParams={searchParams}
-          isSticky
         />
       </div>
       <AddToCart

--- a/src/app/(main)/seat-covers/components/SeatContent.tsx
+++ b/src/app/(main)/seat-covers/components/SeatContent.tsx
@@ -18,8 +18,6 @@ import ReviewsTextTrigger from '../../[productType]/components/ReviewsTextTrigge
 import SeatCoverSelection from './SeatCoverSelector';
 import { deslugify } from '@/lib/utils';
 import useDetermineType from '@/hooks/useDetermineType';
-import { TSeatCoverDataDB } from '@/lib/db/seat-covers';
-import { handleCheckLowQuantity } from '@/lib/utils/calculations';
 import KlarnaIcon from '@/components/icons/KlarnaIcon';
 
 export default function SeatContent({

--- a/src/app/(main)/seat-covers/components/SeatCoverSelector.tsx
+++ b/src/app/(main)/seat-covers/components/SeatCoverSelector.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { SeatCoverSelectionContext } from '@/contexts/SeatCoverContext';
 import { useStore } from 'zustand';
 import { TSeatCoverDataDB } from '@/lib/db/seat-covers';

--- a/src/app/api/admin-panel/order-items/route.ts
+++ b/src/app/api/admin-panel/order-items/route.ts
@@ -1,14 +1,6 @@
-import {
-  DISCOUNT_25_LOWER_BOUND,
-  DISCOUNT_25_UPPER_BOUND,
-  NO_DISCOUNT_LOWER_BOUND,
-  NO_DISCOUNT_UPPER_BOUND,
-} from '@/lib/constants';
 import { getProductAndPriceBySku } from '@/lib/db/admin-panel/products';
 import { createSupabaseAdminPanelServerClient } from '@/lib/db/adminPanelSupabaseClient';
 import { ADMIN_PANEL_ORDER_ITEMS } from '@/lib/db/constants/databaseTableNames';
-import { handleCheckLowQuantity } from '@/lib/utils/calculations';
-import { IProductData } from '@/utils';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 import { cookies } from 'next/headers';
@@ -114,15 +106,11 @@ const createOrderItems = (
       throw new Error(`No product price found for SKU: ${sku}`);
     }
 
-    const { newMSRP: incomingMSRP } = handleCheckLowQuantity(
-      product as IProductData
-    );
-
-    const totalProductPrice = Number((incomingMSRP * quantity).toFixed(2));
+    const totalProductPrice = Number((product.msrp * quantity).toFixed(2));
     const totalProductPricePlusPreorder = 
       product.preorder && product.preorder_discount
-      ? Number(Number(incomingMSRP) - Number(product.preorder_discount)) * quantity
-      : Number(incomingMSRP) * quantity;
+      ? Number(Number(product.msrp) - Number(product.preorder_discount)) * quantity
+      : Number(product.msrp) * quantity;
     const original_price = Number((product.price * quantity).toFixed(2));
     const discount_amount = original_price - totalProductPrice;
 
@@ -130,7 +118,7 @@ const createOrderItems = (
       order_id: order_id,
       product_id: product.id,
       quantity: quantity,
-      price: parseFloat(totalProductPricePlusPreorder).toFixed(2),
+      price: parseFloat(totalProductPricePlusPreorder.toFixed(2)),
       original_price: parseFloat(original_price.toFixed(2)),
       discount_amount: parseFloat(discount_amount.toFixed(2)),
     };

--- a/src/components/cart/AddToCart.tsx
+++ b/src/components/cart/AddToCart.tsx
@@ -14,46 +14,28 @@ import AddToCartButton from './AddToCartButton';
 import useDetermineType from '@/hooks/useDetermineType';
 import AddtoCartSeatSelect from '../../app/(main)/seat-covers/components/AddToCartSeatSelect';
 import useStoreContext from '@/hooks/useStoreContext';
-import { isFullSet } from '@/lib/utils';
 
 export default function AddToCart({
   selectedProduct,
   handleAddToCart,
   searchParams,
-  isSticky,
 }: {
   selectedProduct: any;
   handleAddToCart: () => void;
   searchParams: TQueryParams;
-  isSticky?: boolean;
 }) {
   const params = useParams<TPathParams>();
   const store = useStoreContext();
   if (!store) throw new Error('Missing Provider in the tree');
   const modelData = useStore(store, (s) => s.modelData);
-  const selectedSetDisplay = useStore(store, (s) => s.selectedSetDisplay); // Not sure what to do about typing here, will research later
-  const selectedColor = useStore(store, (s) => s.selectedColor);
   const { isSeatCover } = useDetermineType();
-  const filteredData = isSeatCover
-    ? modelData.filter(
-        (product) =>
-          isFullSet(product.display_set ?? '') ===
-          selectedSetDisplay?.toLowerCase()
-      )
-    : modelData;
 
-  const isSelectedColorAvailable = filteredData.some(
-    (product) =>
-      product?.display_color?.toLowerCase() === selectedColor.toLowerCase() &&
-      product.quantity !== '0'
-  );
 
   const [addToCartSelectorOpen, setAddToCartSelectorOpen] =
     useState<boolean>(false);
   const initalLoadingState = false;
   const [isLoading, setIsLoading] = useState<boolean>(initalLoadingState);
   const [selectSeatOpen, setSelectSeatOpen] = useState<boolean>(false);
-  const isFinalSelection = params?.year;
 
   const {
     completeSelectionState: { isComplete },
@@ -62,9 +44,6 @@ export default function AddToCart({
   });
 
   const handleAddToCartClicked = () => {
-    // if (isSeatCover && isSelectedColorAvailable === false) {
-    //   return; // Don't want to open add to cart selector
-    // }
     setIsLoading(true);
     if (isComplete) {
       handleAddToCart();
@@ -99,9 +78,6 @@ export default function AddToCart({
       </div>
 
       {/* Add to Cart Button */}
-      {/* {!isFinalSelection && !isSticky ? (
-        <VehicleSelector searchParams={searchParams} />
-      ) : ( */}
       <div className="fixed inset-x-0 bottom-0 z-20 flex bg-white p-4 lg:relative lg:p-1">
         <AddToCartButton
           preorder={selectedProduct.preorder}
@@ -110,7 +86,6 @@ export default function AddToCart({
           isLoading={isLoading}
         />
       </div>
-      {/* )} */}
     </Suspense>
   );
 }

--- a/src/lib/constants.tsx
+++ b/src/lib/constants.tsx
@@ -970,8 +970,3 @@ export const STANDARD_PRO_URL_PARAM = 'standard-pro';
 export const STANDARD_URL_PARAM = 'standard';
 
 export const SHIPPING_METHOD = 'Standard: UPS Ground - Free Shipping';
-
-export const NO_DISCOUNT_LOWER_BOUND = 0;
-export const NO_DISCOUNT_UPPER_BOUND = 2;
-export const DISCOUNT_25_LOWER_BOUND = 3;
-export const DISCOUNT_25_UPPER_BOUND = 5;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,18 +1,8 @@
 import { TInitialProductDataDB } from './db/index';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import {
-  DISCOUNT_25_LOWER_BOUND,
-  DISCOUNT_25_UPPER_BOUND,
-  NO_DISCOUNT_LOWER_BOUND,
-  NO_DISCOUNT_UPPER_BOUND,
-  modelStrings,
-} from './constants';
+import { modelStrings } from './constants';
 import { TCarCoverData } from '@/app/(main)/car-covers/components/CarPDP';
-import { TCartItem } from './cart/useCart';
-import { Dispatch, SetStateAction } from 'react';
-import { IProductData } from '@/utils';
-import { TSeatCoverDataDB } from './db/seat-covers';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/src/lib/utils/calculations.ts
+++ b/src/lib/utils/calculations.ts
@@ -1,12 +1,4 @@
-import { IProductData } from '@/utils';
 import { TCartItem } from '../cart/useCart';
-import {
-  NO_DISCOUNT_LOWER_BOUND,
-  NO_DISCOUNT_UPPER_BOUND,
-  DISCOUNT_25_LOWER_BOUND,
-  DISCOUNT_25_UPPER_BOUND,
-} from '../constants';
-import { TSeatCoverDataDB } from '../db/seat-covers';
 
 export const getOrderSubtotal = (cartItems: TCartItem[]) => {
   return cartItems.reduce(
@@ -42,12 +34,4 @@ export const getTotalDiscountPrice = (cartItems: TCartItem[]) => {
 
 export const getTotalCartQuantity = (cartItems: TCartItem[]) => {
   return cartItems.reduce((total, item) => total + item.quantity, 0);
-};
-
-export const handleCheckLowQuantity = (
-  cartProduct: IProductData | TSeatCoverDataDB
-) => {
-  if (!cartProduct || !cartProduct.msrp) return;
-
-  return { discountPercent: 50, newMSRP: cartProduct.msrp };
 };


### PR DESCRIPTION
Objective: remove discounts based on product quantity (everywhere: product page [seat covers/car covers], orderItem generation, and relevant functions ie handleLowQuantity from calculations lib)

Refer to this PR : https://github.com/devwilliamy/coverland/pull/534/files
because basically I mostly reverted the code while keeping a tad bit for preorder case

Notes:
- didn't change in cart item / addToCart (I thought it would be useful for future case if we ever have no discount on any item this would catch this scenario)
- I also cleaned up really old unused code like Image / react-player(?)

Testing:
**you cannot compare product data from the main/preview branch deployments because the discount "bounds" are hard coded to 50 (see image below)**
![Screenshot 2024-07-15 105927](https://github.com/user-attachments/assets/84e97fd2-27ad-4871-b7a6-17d5108fdf78)
-use this old deployment for comparison to this PR:
https://coverland-2-0-mf6sl10ga-coverland-3615f02b.vercel.app/car-covers/premium-plus/land-rover/defender-110/2012-2016

-test car cover products (and respective individual colors) to see they are clickable and display the correct 50% discount (there should no longer be a product with a full price for example)
-same for seat covers
-check that the seat cover preorder discount is still being displayed when it's added to the cart (not on the product page) but on the preorder modal slider
- check the items and msrp persist to cart / checkout
- check the orderItem and order are properly generated with the correct prices