### PR TITLE
Fix Delivery Date For Out Of Range Timezone

### DIFF
--- a/src/lib/utils/deliveryDateUtils.ts
+++ b/src/lib/utils/deliveryDateUtils.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 
 export const getClientTimeZone = (): string => {
   const timeZoneOffset: number = new Date().getTimezoneOffset();
+  const clientTimeZone: string = DateTime.local().zoneName;
   // Timezone offset in minutes for PST, MST, CST, EST
   const PST: number = 480; // UTC -8
   const MST: number = 420; // UTC -7
@@ -18,7 +19,7 @@ export const getClientTimeZone = (): string => {
   } else if (timeZoneOffset === EST) {
     return 'America/New_York';
   } else {
-    return 'Unknown';
+    return clientTimeZone || 'UTC';
   }
 };
 
@@ -28,11 +29,15 @@ export const getClientTimeZone = (): string => {
  * If after 2 PM, add another day.
  * For MST, it will be 3 days later. For CST, 4 days later. For EST, 5 days later.
  * Currently don't know what to do for other time zones and defaulting to 5 days later.
- * 
+ *
  * @param format string : format of the date output | default -> "Jul 15" | "EEE, LLL dd" -> "Mon, Jul 15"
  * @returns string
  */
-export const determineDeliveryByDate = (format = 'LLL dd', preorder_date?: string): string => {
+export const determineDeliveryByDate = (
+  format = 'LLL dd',
+  preorder_date?: string
+): string => {
+  debugger;
   const clientTimeZone: string = getClientTimeZone();
   let now: DateTime = DateTime.now().setZone(clientTimeZone);
   let daysToAdd: number;
@@ -58,7 +63,7 @@ export const determineDeliveryByDate = (format = 'LLL dd', preorder_date?: strin
       daysToAdd = 5;
       break;
     default:
-      daysToAdd = 0; // Adjusted if needed
+      daysToAdd = 5; // Default for "other" cases
   }
 
   // If it's after 2 PM, add an extra day

--- a/src/lib/utils/deliveryDateUtils.ts
+++ b/src/lib/utils/deliveryDateUtils.ts
@@ -37,7 +37,6 @@ export const determineDeliveryByDate = (
   format = 'LLL dd',
   preorder_date?: string
 ): string => {
-  debugger;
   const clientTimeZone: string = getClientTimeZone();
   let now: DateTime = DateTime.now().setZone(clientTimeZone);
   let daysToAdd: number;


### PR DESCRIPTION
Fixing issue similar to #584
Users outside of our date range were getting Invalid DateTime
Could have sworn "Unknown" worked though so not sure what happened there