### PR TITLE
Updated preorder email to say weeks instead of months

### DIFF
--- a/src/components/checkout/CheckoutAccordion.tsx
+++ b/src/components/checkout/CheckoutAccordion.tsx
@@ -11,7 +11,6 @@ import {
   AccordionTrigger,
 } from '../ui/accordion';
 import CartHeader from './CartHeader';
-import { Separator } from '../ui/separator';
 import { MouseEvent, useEffect, useState } from 'react';
 import InYourCart from './InYourCart';
 import { useCartContext } from '@/providers/CartProvider';
@@ -30,34 +29,23 @@ import {
   getSkuQuantityPriceFromCartItemsForMeta,
   getSkusFromCartItems,
 } from '@/lib/utils/stripe';
-import { getCurrentDayInLocaleDateString } from '@/lib/utils/date';
+import {
+  getCurrentDayInLocaleDateString,
+  weeksFromCurrentDate,
+} from '@/lib/utils/date';
 import { v4 as uuidv4 } from 'uuid';
 import { hashData } from '@/lib/utils/hash';
 import { getCookie } from '@/lib/utils/cookie';
-import {
-  CreatePaymentMethodKlarnaData,
-  PaymentMethodCreateParams,
-  PaymentRequestShippingOption,
-  StripeExpressCheckoutElementOptions,
-} from '@stripe/stripe-js';
 import { useRouter } from 'next/navigation';
 import PayPalButtonSection from './PayPalButtonSection';
 import { generateSkuLabOrderInput } from '@/lib/utils/skuLabs';
 import { handlePurchaseGoogleTag } from '@/hooks/useGoogleTagDataLayer';
 import { SHIPPING_METHOD } from '@/lib/constants';
-import {
-  checkTimeDifference,
-  determineDeliveryByDate,
-} from '@/lib/utils/deliveryDateUtils';
-import { TCartItem } from '@/lib/cart/useCart';
+import { determineDeliveryByDate } from '@/lib/utils/deliveryDateUtils';
 import { ReadyCheck } from './icons/ReadyCheck';
 import { useMediaQuery } from '@mantine/hooks';
 import CheckoutSummarySection from './CheckoutSummarySection';
 import OrderReview from './OrderReview';
-import parsePhoneNumberFromString, {
-  findPhoneNumbersInText,
-  parsePhoneNumber,
-} from 'libphonenumber-js';
 import { formatToE164 } from '@/lib/utils';
 import { TermsOfUseStatement } from './TermsOfUseStatement';
 
@@ -108,7 +96,7 @@ export default function CheckoutAccordion() {
   const [paypalSuccessMessage, setPaypalSuccessMessage] = useState('');
   const preorderDate = isCartPreorder ? cartPreorderDate : undefined;
   const preOrderTimeDifferenceText: string = isCartPreorder
-    ? `approximately ${checkTimeDifference(cartPreorderDate)} from the date of purchase.`
+    ? `approximately ${weeksFromCurrentDate(cartPreorderDate)} weeks from the date of purchase.`
     : 'noted above.'; // If some random failure happens with checkTimeDifference, default here
 
   const shippingInfo = {

--- a/src/components/checkout/PayPalButtonSection.tsx
+++ b/src/components/checkout/PayPalButtonSection.tsx
@@ -18,18 +18,17 @@ import {
   getSkusFromCartItems,
 } from '@/lib/utils/stripe';
 import { createOrUpdateUser } from '@/lib/db/admin-panel/customers';
-import { getCurrentDayInLocaleDateString } from '@/lib/utils/date';
+import {
+  getCurrentDayInLocaleDateString,
+  weeksFromCurrentDate,
+} from '@/lib/utils/date';
 import { handlePurchaseGoogleTag } from '@/hooks/useGoogleTagDataLayer';
 import { hashData } from '@/lib/utils/hash';
 import { getCookie } from '@/lib/utils/cookie';
 import { v4 as uuidv4 } from 'uuid';
 import { generateSkuLabOrderInput } from '@/lib/utils/skuLabs';
-import {
-  checkTimeDifference,
-  determineDeliveryByDate,
-} from '@/lib/utils/deliveryDateUtils';
+import { determineDeliveryByDate } from '@/lib/utils/deliveryDateUtils';
 import { SHIPPING_METHOD } from '@/lib/constants';
-import parsePhoneNumberFromString from 'libphonenumber-js';
 import { formatToE164 } from '@/lib/utils';
 
 type PaypalButtonSectionProps = {
@@ -69,7 +68,7 @@ export default function PayPalButtonSection({
   const router = useRouter();
   const totalMsrpPrice = getTotalPrice().toFixed(2) as unknown as number;
   const preOrderTimeDifferenceText: string = isCartPreorder
-    ? `approximately ${checkTimeDifference(cartPreorderDate)} from the date of purchase.`
+    ? `approximately ${weeksFromCurrentDate(cartPreorderDate)} weeks from the date of purchase.`
     : 'noted above.'; // If some random failure happens with checkTimeDifference, default here
 
   return (

--- a/src/components/checkout/PriceBreakdown.tsx
+++ b/src/components/checkout/PriceBreakdown.tsx
@@ -30,7 +30,7 @@ export default function PriceBreakdown() {
 
   return (
     <div className=" text-base font-normal text-[#343434]">
-      <div className="flex justify-between lg:flex">
+      <div className="flex justify-between pt-2 lg:flex">
         <div>Order Subtotal</div>
         <div>${orderSubtotal}</div>
       </div>

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -75,6 +75,12 @@ export function formatISODateNoTimeZone(isoDateString: string): string {
   return `${month}/${day}/${year}`;
 }
 
+/**
+ * Calculates value of weeks from current date.
+ * Note: Only returns the number. Don't forget to add "weeks" after
+ * @param targetDate 
+ * @returns 
+ */
 export function weeksFromCurrentDate(targetDate: string): number {
   const currentDate = new Date();
   const target = new Date(targetDate);

--- a/src/lib/utils/deliveryDateUtils.ts
+++ b/src/lib/utils/deliveryDateUtils.ts
@@ -75,8 +75,13 @@ export const determineDeliveryByDate = (
   return deliveryDate.toFormat(format);
 };
 
+/**
+ * Checks the time difference between now and the date.
+ * Will return 1-4 weeks, after that will do by months.
+ * @param date 
+ * @returns 
+ */
 export const checkTimeDifference = (date: string): string => {
-  debugger;
   const targetDate = DateTime.fromISO(date);
   const now = DateTime.now();
 


### PR DESCRIPTION
Calvin wanted the preorder email text to say approximately timeframe in weeks

"The estimated fulfillment timeframe is approximately 4 months from the date of purchase. " ->
"The estimated fulfillment timeframe is approximately 16 weeks from the date of purchase. "