### PR TITLE
Changed MX to UN for unknowns

### DIFF
--- a/src/lib/utils/stripe.ts
+++ b/src/lib/utils/stripe.ts
@@ -74,7 +74,7 @@ export const getProductInitialsForType = (type: string): string => {
     case 'Accessories':
       return 'AC';
     default:
-      return 'MX';
+      return 'UN';
   }
 };
 


### PR DESCRIPTION
Having an issue where if a product is purchased but it doesn't exist in our db, the SKU doesn't exist

MX was the default, but this is meant for mixed products

So changing unknown / default to be UN instead