### PR TITLE
If SKU Missing will bring in seat cover (on seat cove ronly)

### DIFF
--- a/src/app/(main)/seat-covers/components/SeatContent.tsx
+++ b/src/app/(main)/seat-covers/components/SeatContent.tsx
@@ -70,7 +70,8 @@ export default function SeatContent({
     if (!selectedProduct.sku) {
       const params = {
         ...searchParams,
-        submodel1: searchParams.submodel,
+        type: 'Seat Covers',
+        submodel1: searchParams.submodel, // Because the search params is submodel instead of submodel1
       };
       addToCart({ ...selectedProduct, ...params, quantity: 1 });
     } else if (newMSRP !== 0) {


### PR DESCRIPTION
Stripe item name was showing Car Cover if SKU was missing
Adjusting so will add it in for seat cover if this happens