### PR TITLE
Links SKU Lab Item to SKU Lab Order

### DIFF
--- a/src/lib/db/constants/databaseTableNames.ts
+++ b/src/lib/db/constants/databaseTableNames.ts
@@ -21,6 +21,7 @@ export const ADMIN_PANEL_CUSTOMERS = 'users';
 export const MODEL_TABLE = 'Model';
 export const MAKE_TABLE = 'Make';
 export const PRODUCT_METADATA_TABLE = 'Product-Metadata';
+export const SKU_LAB_SKU_ITEM_ID_MAP_TABLE = 'sku_lab_sku_item_id_map';
 
 /* Supabase RPC Names */
 export const RPC_GET_MAKE_RELATION = 'get_make_relation';

--- a/src/lib/db/sku-labs/index.ts
+++ b/src/lib/db/sku-labs/index.ts
@@ -1,0 +1,28 @@
+import { SKU_LAB_SKU_ITEM_ID_MAP_TABLE } from '../constants/databaseTableNames';
+import { supabaseDatabaseClient } from '../supabaseClients';
+
+export async function getSkuLabItemId(sku: string) {
+  try {
+    const { data, error } = await supabaseDatabaseClient
+      .from(SKU_LAB_SKU_ITEM_ID_MAP_TABLE)
+      .select('item_id')
+      .eq('sku', sku)
+      .maybeSingle();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        // This error code indicates no rows were returned
+        console.log(`[getSkuLabItemId]: No item found for sku: ${sku}`);
+        return null;
+      }
+      throw new Error(
+        `[getSkuLabItemId]: Failed to fetch item with sku: ${sku}. ${error.message}`
+      );
+    }
+
+    return data?.item_id ?? null;
+  } catch (error) {
+    console.error(`[getSkuLabItemId]: An unexpected error occurred`, error);
+    throw error; // Re-throw the error for the caller to handle
+  }
+}


### PR DESCRIPTION
Takes awhile to link items and there's a lot of orders so automating as much as that process as possible.

Need to use the sku-lab-update-quantity project, it's been repurposed to map SKU Labs SKU to ItemID.

That script should work and insert new ones only to the table.

Note: currently doesn't work for full seat sets (these are kits). Will figure that out later.
Also doesn't work for some pre orders if they don't exist in SKU Labs yet. 
Probably have to run the script whenever there's a new preorder sheet.

