### PR TITLE
Updated preorder preview to show discount amount not total amount

### DIFF
--- a/src/components/cart/PreorderPreview.tsx
+++ b/src/components/cart/PreorderPreview.tsx
@@ -33,7 +33,7 @@ const PreorderPreview = ({ selectedProduct }: PreorderPreviewProps) => {
               {preorderWeeks} Weeks
             </div>
             <div className="w-[75px] rounded bg-[#2BA45B] py-1 text-center text-[#ffffff]">
-              ${totalPreorderDiscount} Off
+              ${selectedProduct?.preorder_discount || 0} Off
             </div>
           </div>
         </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a08938f3-f3bb-4371-9dba-777b1a275bca)
[CK] It seems that when a user clicks on one option and then exits out to click on another, the price keeps adding up. Can you adjust it so that only the price of the selected seat cover is shown, without adding the previous selections?