### PR TITLE
Dropdown: Update parent generation when submodel1 is selected

### DIFF
--- a/src/components/hero/dropdown/SubmodelDropdown.tsx
+++ b/src/components/hero/dropdown/SubmodelDropdown.tsx
@@ -20,7 +20,7 @@ export function SubmodelDropdown({
     []
   );
 
-  const { query } = queryObj;
+  const { query, setQuery } = queryObj;
   const { model, submodel1 } = query;
 
   const filteredSubmodelData = Array.from(
@@ -34,6 +34,17 @@ export function SubmodelDropdown({
   ).map((submodel) => ({
     name: submodel,
   }));
+
+  useEffect(() => {
+    if (submodel1) {
+      const parent_generation =
+        submodelData.find((car) => car.submodel1 === submodel1)?.parent_generation || '';
+      setQuery((p) => ({
+        ...p,
+        parent_generation,
+      }));
+    }
+  }, [submodel1, submodelData, setQuery]);
 
   useEffect(() => {
     // Check for second submodel


### PR DESCRIPTION
Was having some issues where if the submodel had a different generation, it was possible the wrong parent generation was being picked up.

I added a parent generation update when submodel is picked to update to the parent generation of the submodel1 that was picked.