### PR TITLE
TrustPilot Email Sent On Shipping Confirmation Instead Of Thank You Email Now

### DIFF
--- a/src/app/api/sku-labs/orders/status/webhook/route.ts
+++ b/src/app/api/sku-labs/orders/status/webhook/route.ts
@@ -139,29 +139,30 @@ export async function POST(request: NextRequest): Promise<SkuLabOrderResponse> {
         `[sku-labs/orders/status/webhook] ${getTimestamp()}: Order updated successfully: ${order_number}`
       );
       /*
-      
-        [TODO]: Send Tracking Number Email.
-
+        Send Tracking Number Email.
       */
 
       const fullOrderData = await fetchUserOrderById(data[0].id);
 
       const emailTo = fullOrderData?.customer_email;
+      if (fullOrderData) {
+        const toSendgrid = {
+          to: emailTo,
+          dynamic_template_data:
+            generateDynamicTemplateDataFromUserOrder(fullOrderData),
+        };
 
-      const toSendgrid = {
-        to: emailTo,
-        dynamic_template_data:
-          generateDynamicTemplateDataFromUserOrder(fullOrderData),
-      };
-
-      await sendShippingConfirmationEmailToSendGrid(
-        generateSendGridApiPayload(toSendgrid)
-      );
+        await sendShippingConfirmationEmailToSendGrid(
+          generateSendGridApiPayload(toSendgrid)
+        );
+      } else {
+        console.error(
+          '[/sku-labs/orders/status/webhook]: Could not find fullOrderData'
+        );
+      }
 
       /*
-      
         [TODO]: Have to update Stripe and Paypal Tracking Number Here too
-
       */
 
       return NextResponse.json(

--- a/src/components/checkout/CheckoutAccordion.tsx
+++ b/src/components/checkout/CheckoutAccordion.tsx
@@ -311,28 +311,6 @@ export default function CheckoutAccordion() {
       );
     }
 
-    const skuLabOrderInput = await generateSkuLabOrderInput({
-      orderNumber,
-      cartItems,
-      orderTotal,
-      shippingAddress,
-      customerInfo,
-      paymentMethod: 'Stripe',
-      tax,
-      discount: Number((getTotalPreorderDiscount() * -1).toFixed(2)),
-      shipping,
-    });
-
-    // SKU Labs Order Creation
-    // Post Items
-    const skuLabCreateOrderResponse = await fetch('/api/sku-labs/orders', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ order: skuLabOrderInput }),
-    });
-
     router.push(
       `/thank-you?order_number=${orderNumber}&payment_intent=${id}&payment_intent_client_secret=${client_secret}`
     );

--- a/src/components/checkout/PayPalButtonSection.tsx
+++ b/src/components/checkout/PayPalButtonSection.tsx
@@ -30,7 +30,6 @@ import { generateSkuLabOrderInput } from '@/lib/utils/skuLabs';
 import { determineDeliveryByDate } from '@/lib/utils/deliveryDateUtils';
 import { SHIPPING_METHOD } from '@/lib/constants';
 import { formatToE164 } from '@/lib/utils';
-import { generateTrustPilotPayload } from '@/lib/trustpilot';
 
 type PaypalButtonSectionProps = {
   setPaypalSuccessMessage: (message: string) => void;
@@ -210,12 +209,6 @@ export default function PayPalButtonSection({
                   free_delivery: shippingInfo.delivery_fee === 0,
                   tax: tax.toFixed(2),
                 },
-                trustPilot: generateTrustPilotPayload(
-                  shippingAddress.name,
-                  customerInfo.email,
-                  orderNumber,
-                  cartItems
-                ),
                 // billingInfo,
               };
               const emailResponse = await fetch('/api/email/thank-you', {

--- a/src/lib/sendgrid/emails/thank-you.ts
+++ b/src/lib/sendgrid/emails/thank-you.ts
@@ -152,12 +152,10 @@ const generateThankYouEmail = ({
   orderInfo,
   shippingInfo,
   billingInfo,
-  trustPilot,
 }: ThankYouEmailInput) => ({
   personalizations: [
     {
       to: [{ email: to }],
-      bcc: [process.env.TRUST_PILOT_BCC_EMAIL],
       dynamic_template_data: {
         first_name: name.firstName,
         order_date: orderInfo.orderDate,
@@ -179,12 +177,6 @@ const generateThankYouEmail = ({
           orderInfo.totalPreorderDiscount
         ),
         total: formatMoneyAsNumber(orderInfo.total),
-        // For Trust Pilot
-        recipientName: trustPilot.recipientName,
-        recipientEmail: trustPilot.recipientEmail,
-        referenceId: trustPilot.referenceId,
-        products: trustPilot.products,
-        // End For Trust Pilot
       },
     },
   ],

--- a/src/lib/trustpilot/index.ts
+++ b/src/lib/trustpilot/index.ts
@@ -1,4 +1,4 @@
-import { TCartItem } from '../cart/useCart';
+import { TOrderItem, TOrderItemProduct } from '../db/orders/getOrderByOrderId';
 import { slugify } from '../utils';
 import { generateItemName } from '../utils/stripe';
 
@@ -26,7 +26,7 @@ export const generateTrustPilotPayload = (
   name: string,
   email: string,
   orderNumber: string,
-  cartItems: TCartItem[]
+  orderItems: TOrderItem[]
 ): TrustPilotReviewInvitation => {
   return {
     recipientName: name,
@@ -34,17 +34,17 @@ export const generateTrustPilotPayload = (
     referenceId: orderNumber,
     // productReviewInvitationPreferredSendTime: '2018-12-25T13:00:00',
     // productReviewInvitationTemplateId: 'insert your product review template ID',
-    products: generateTrustPilotProducts(cartItems),
+    products: generateTrustPilotProducts(orderItems),
   };
 };
 
-const generateTrustPilotProducts = (cartItems: TCartItem[]) => {
-  return cartItems.map((item) => {
-    const { product, sku, gtin, mpn } = item;
+const generateTrustPilotProducts = (orderItems: TOrderItem[]) => {
+  return orderItems.map((item) => {
+    const { product, sku, gtin, mpn } = item.product;
     return {
-      productUrl: generateProductUrl(item),
+      productUrl: generateProductUrl(item.product),
       imageUrl: product?.split(',')[0] || '',
-      name: generateItemName(item),
+      name: generateItemName(item.product),
       sku: sku || '',
       gtin: gtin || '',
       mpn: mpn || '',
@@ -62,19 +62,19 @@ const createQueryString = (name: string, value: string) => {
 
 /**
  * Takes cart item and generates website URL from it
- * @param cartItem
+ * @param orderItemProduct
  * @returns
  */
-const generateProductUrl = (cartItem: TCartItem) => {
+const generateProductUrl = (orderItemProduct: TOrderItemProduct) => {
   // const host = process.env.NEXT_PUBLIC_HOSTNAME;
-  const host = "https://coverland.com"; // Will just default this to Coverland
-  const type = cartItem?.type ?? '';
-  const make = cartItem?.make ?? '';
-  const model = cartItem?.model ?? '';
-  const parent_generation = cartItem?.parent_generation;
-  const submodel1 = cartItem?.submodel1 ?? '';
-  const submodel2 = cartItem?.submodel2 ?? '';
-  const submodel3 = cartItem?.submodel3 ?? '';
+  const host = 'https://coverland.com'; // Will just default this to Coverland
+  const type = orderItemProduct?.type ?? '';
+  const make = orderItemProduct?.make ?? '';
+  const model = orderItemProduct?.model ?? '';
+  const parent_generation = orderItemProduct?.parent_generation;
+  const submodel1 = orderItemProduct?.submodel1 ?? '';
+  const submodel2 = orderItemProduct?.submodel2 ?? '';
+  const submodel3 = orderItemProduct?.submodel3 ?? '';
   const determineType = type !== 'Seat Covers' ? 'premium-plus' : 'leather';
   let url = `${host}/${slugify(type)}/${determineType}/${slugify(make)}/${slugify(model)}/${parent_generation}`;
   if (submodel1) {


### PR DESCRIPTION
Didn't make sense to send the email for pre orders so we're having the surveys happen when shipping occurs

Should be when order arrives TBH, but we don't have it yet.

Had to update trustPilot function to use TOrderItem instead of TCartItem, there's just a layer of product to dig into for the same information so not a big deal.