### PR TITLE
Removing trust pilot from shipping confirmation

### DIFF
--- a/src/lib/sendgrid/emails/shipping-confirmation.ts
+++ b/src/lib/sendgrid/emails/shipping-confirmation.ts
@@ -163,7 +163,7 @@ export const generateDynamicTemplateDataFromUserOrder = (
     main_data,
     // order_items,
     shipping_info,
-    trust_pilot,
+    // trust_pilot,
   };
 };
 
@@ -174,7 +174,7 @@ export const generateSendGridApiPayload = (data): MailDataRequired => {
     personalizations: [
       {
         to: [{ email: data.to }], // data.to
-        bcc: [process.env.TRUST_PILOT_BCC_EMAIL],
+        // bcc: [process.env.TRUST_PILOT_BCC_EMAIL],
         dynamicTemplateData: data.dynamic_template_data,
       },
     ],


### PR DESCRIPTION
Customers getting reviews when not received product yet.
Part of it due to the reviews being sent between 8/15 - 8/29 (when it was upon purchase).
Part of it due to people just printing labels and triggering the shipping confirmation email.
Getting lot of 1* reviews due to people not receiving their product yet.

Removing until end of October ish.