### PR TITLE
Changed addressline validation regex

### DIFF
--- a/src/components/checkout/CustomTextField.tsx
+++ b/src/components/checkout/CustomTextField.tsx
@@ -43,25 +43,25 @@ export const CustomTextField = ({
     return re.test(String(email).toLowerCase());
   };
 
-  const validateLengthGreaterThanOne = (inputString: string) => {
+  const validateLengthGreaterThanOne = (input: string) => {
     // Regex to match strings with more than one alphabetic character
 
-    if (!inputString) {
+    if (!input) {
       return false;
     }
 
     const pattern = /\b[a-zA-Z]{2,}\b/g;
-    return pattern.test(inputString);
+    return pattern.test(input);
   };
 
-  const validatePostal = (inputString: string) => {
+  const validatePostal = (input: string) => {
     // Regex pattern to check if the input is a number of max length 5
     const pattern = /^\d{5}$/;
-    return pattern.test(inputString);
+    return pattern.test(input);
   };
 
-  const isValidPhoneNumber = (inputString: string) => {
-    const cleanedInput = cleanPhoneInput(inputString);
+  const isValidPhoneNumber = (input: string) => {
+    const cleanedInput = cleanPhoneInput(input);
 
     if (cleanedInput.length < 10) {
       return false;
@@ -70,7 +70,17 @@ export const CustomTextField = ({
     // Regex pattern to check if the input is a valid phone number
     const pattern =
       /^\+?(\d{1,3})?[-.\s]?(\(\d{1,4}\)|\d{1,4})[-.\s]?\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{1,9}$/;
-    return pattern.test(inputString);
+    return pattern.test(input);
+  };
+
+  const isValidAddressLine1 = (input: string) => {
+    const pattern = /^[a-zA-Z0-9\s\#\-\.\,\/\\]{3,100}$/;
+    return pattern.test(input);
+  };
+
+  const isValidAddressLine2 = (input: string) => {
+    const pattern = /[a-zA-Z0-9\s\#\-\.\,\/\\]{1,100}$/;
+    return pattern.test(input);
   };
 
   const isValidInput = (value: string) => {
@@ -81,6 +91,10 @@ export const CustomTextField = ({
         return validatePostal(value);
       case 'phoneNumber':
         return isValidPhoneNumber(value);
+      case 'line1':
+        return isValidAddressLine1(value);
+      case 'line2':
+        return isValidAddressLine2(value);
       default:
         return validateLengthGreaterThanOne(value);
     }


### PR DESCRIPTION
Was having an issue where this address wasn't working

![image](https://github.com/user-attachments/assets/b126e6e8-bd7c-4748-a1c3-5a89f9a8f6b2)

Previous validation would check if each word was only 1 letter so this failed.
Updating it to just do 3 characters or more, restricting certain symbols