### PR TITLE
Car Cover Color Arrange & Seat Cover Color Fix

### DIFF
--- a/src/app/(main)/[productType]/components/CircleColorSelector.tsx
+++ b/src/app/(main)/[productType]/components/CircleColorSelector.tsx
@@ -46,9 +46,19 @@ export default function CircleColorSelector() {
 
   const uniqueColors: IProductData[] = Array.from(
     new Set(modelData.map((model) => model.display_color))
-  ).map((color) =>
-    modelData.find((model) => model.display_color === color)
-  ) as IProductData[];
+  )
+    .map((color) => modelData.find((model) => model.display_color === color))
+    .sort((a, b) => {
+      // Check for preorder
+      if (a?.preorder && !b?.preorder) {
+        return 1; // Place 'a' after 'b'
+      } else if (!a?.preorder && b?.preorder) {
+        return -1; // Place 'a' before 'b'
+      }
+
+      // You can add additional sorting logic here, e.g., by `display_color`
+      // return a?.display_color?.localeCompare(b?.display_color || '') || 0;
+    }) as IProductData[];
 
   const handleColorChange = (newSelectedProduct: IProductData) => {
     handleViewItemColorChangeGoogleTag(newSelectedProduct, params, isComplete);

--- a/src/app/(main)/[productType]/components/CircleColorSelector.tsx
+++ b/src/app/(main)/[productType]/components/CircleColorSelector.tsx
@@ -46,19 +46,9 @@ export default function CircleColorSelector() {
 
   const uniqueColors: IProductData[] = Array.from(
     new Set(modelData.map((model) => model.display_color))
-  )
-    .map((color) => modelData.find((model) => model.display_color === color))
-    .sort((a, b) => {
-      // Check for preorder
-      if (a?.preorder && !b?.preorder) {
-        return 1; // Place 'a' after 'b'
-      } else if (!a?.preorder && b?.preorder) {
-        return -1; // Place 'a' before 'b'
-      }
-
-      // You can add additional sorting logic here, e.g., by `display_color`
-      // return a?.display_color?.localeCompare(b?.display_color || '') || 0;
-    }) as IProductData[];
+  ).map((color) =>
+    modelData.find((model) => model.display_color === color)
+  ) as IProductData[];
 
   const handleColorChange = (newSelectedProduct: IProductData) => {
     handleViewItemColorChangeGoogleTag(newSelectedProduct, params, isComplete);

--- a/src/app/(main)/seat-covers/components/SeatCoverColorSelector.tsx
+++ b/src/app/(main)/seat-covers/components/SeatCoverColorSelector.tsx
@@ -30,6 +30,54 @@ const iconMap: Record<string, StaticImageData> = {
   Brown: CircleBrown,
 };
 
+const ALL_SEAT_COLORS = [
+  {
+    display_color: 'black',
+    product:
+      'http://www.coverland.com/custom-leather-seat-cover/01-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/02-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/03-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/04-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/05-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/06-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/07-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/08-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/09-seatcover-pc-bk-1to.webp',
+  },
+  {
+    display_color: 'gray',
+    product:
+      'http://www.coverland.com/custom-leather-seat-cover/01-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/02-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/03-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/04-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/05-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/06-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/07-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/08-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/09-seatcover-pc-gr-1to.webp',
+  },
+  {
+    display_color: 'beige',
+    product:
+      'http://www.coverland.com/custom-leather-seat-cover/01-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/02-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/03-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/04-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/05-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/06-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/07-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/08-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/09-seatcover-pc-be-1to.webp',
+  },
+  {
+    display_color: 'dark gray',
+    product:
+      'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-dg-1to.webp',
+  },
+  {
+    display_color: 'red',
+    product:
+      'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-rd-1to.webp',
+  },
+  {
+    display_color: 'pink',
+    product:
+      'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-pk-1to.webp',
+  },
+  {
+    display_color: 'white',
+    product:
+      'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-wh-1to.webp',
+  },
+  {
+    display_color: 'dark brown',
+    product:
+      'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-db-1to.webp',
+  },
+  {
+    display_color: 'brown',
+    product:
+      'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-br-1to.webp',
+  },
+];
+
 export default function SeatCoverColorSelector() {
   const store = useContext(SeatCoverSelectionContext);
   if (!store)
@@ -49,55 +97,7 @@ export default function SeatCoverColorSelector() {
     data: modelData,
   });
 
-  const showColors = [
-    {
-      display_color: 'black',
-      product:
-        'http://www.coverland.com/custom-leather-seat-cover/01-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/02-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/03-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/04-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/05-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/06-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/07-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/08-seatcover-pc-bk-1to.webp,http://www.coverland.com/custom-leather-seat-cover/09-seatcover-pc-bk-1to.webp',
-    },
-    {
-      display_color: 'gray',
-      product:
-        'http://www.coverland.com/custom-leather-seat-cover/01-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/02-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/03-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/04-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/05-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/06-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/07-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/08-seatcover-pc-gr-1to.webp,http://www.coverland.com/custom-leather-seat-cover/09-seatcover-pc-gr-1to.webp',
-    },
-    {
-      display_color: 'beige',
-      product:
-        'http://www.coverland.com/custom-leather-seat-cover/01-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/02-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/03-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/04-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/05-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/06-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/07-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/08-seatcover-pc-be-1to.webp,http://www.coverland.com/custom-leather-seat-cover/09-seatcover-pc-be-1to.webp',
-    },
-    {
-      display_color: 'dark gray',
-      product:
-        'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-dg-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-dg-1to.webp',
-    },
-    {
-      display_color: 'red',
-      product:
-        'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-rd-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-rd-1to.webp',
-    },
-    {
-      display_color: 'pink',
-      product:
-        'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-pk-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-pk-1to.webp',
-    },
-    {
-      display_color: 'white',
-      product:
-        'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-wh-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-wh-1to.webp',
-    },
-    {
-      display_color: 'dark brown',
-      product:
-        'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-db-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-db-1to.webp',
-    },
-    {
-      display_color: 'brown',
-      product:
-        'https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/01-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/02-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/03-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/04-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/05-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/06-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/07-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/08-seatcover-pc-br-1to.webp,https://coverland.sfo3.cdn.digitaloceanspaces.com/custom-leather-seat-cover/09-seatcover-pc-br-1to.webp',
-    },
-  ];
-
-  const getModelDataBySet: TSeatCoverDataDB[] = [
+  const filteredModelsByDisplaySet: TSeatCoverDataDB[] = [
     ...new Map(
       modelData
         .filter(
@@ -109,8 +109,14 @@ export default function SeatCoverColorSelector() {
   ];
 
   const uniqueProductColors = Array.from(
-    new Set(modelData.map((model) => model.display_color))
-  ).map((color) => modelData.find((model) => model.display_color === color));
+    new Set(filteredModelsByDisplaySet.map((model) => model.display_color))
+  ).map((color) =>
+    filteredModelsByDisplaySet.find(
+      (model) =>
+        model.display_color === color &&
+        isFullSet(model.display_set as string) === selectedSetDisplay
+    )
+  );
 
   const allOutOfStock = (availableSeats: TSeatCoverDataDB[]) => {
     return;
@@ -129,16 +135,18 @@ export default function SeatCoverColorSelector() {
     // If that's the case, then the selected product will be 'black'
     // TODO: - Ideally we'd still change the colors but no time at the moment.
     setSelectedProduct(
-      getModelDataBySet[availableColorIndex]
-        ? getModelDataBySet[availableColorIndex]
+      filteredModelsByDisplaySet[availableColorIndex]
+        ? filteredModelsByDisplaySet[availableColorIndex]
         : availableColorIndex === -1
-          ? getModelDataBySet[0]
+          ? filteredModelsByDisplaySet[0]
           : (uniqueProductColors[0] as TSeatCoverDataDB)
     );
 
     setSelectedColor(
-      getModelDataBySet[availableColorIndex]?.display_color?.toLowerCase()
-        ? (getModelDataBySet[
+      filteredModelsByDisplaySet[
+        availableColorIndex
+      ]?.display_color?.toLowerCase()
+        ? (filteredModelsByDisplaySet[
             availableColorIndex
           ]?.display_color?.toLowerCase() as string)
         : (uniqueProductColors[0]?.display_color?.toLowerCase() as string)
@@ -156,7 +164,7 @@ export default function SeatCoverColorSelector() {
         </h3>{' '}
         {!!selectedColor ? (
           <span className="ml-[12px]  text-[#8F8F8F]">
-            {allOutOfStock(getModelDataBySet)
+            {allOutOfStock(filteredModelsByDisplaySet)
               ? 'Out of Stock'
               : !availableColors.includes(selectedColor.toLowerCase()) ||
                   (selectedProduct.preorder && isComplete) // only displays Pre-Order if we are in a final selection product page such as seat-covers/leather/make/model/year and the selected product has preorder set to true
@@ -169,7 +177,7 @@ export default function SeatCoverColorSelector() {
         )}
       </div>
 
-      {allOutOfStock(getModelDataBySet) ? (
+      {allOutOfStock(filteredModelsByDisplaySet) ? (
         <div className="flex w-full min-w-[288px]  gap-[11px] overflow-x-auto py-[1px] md:overflow-x-hidden">
           {uniqueProductColors.map((product, index) => (
             <div
@@ -178,7 +186,7 @@ export default function SeatCoverColorSelector() {
                 relative inline-block cursor-pointer flex-col place-content-center rounded-full p-[2px] `}
               onClick={() => {
                 setColorIndex(index);
-                setSelectedProduct(getModelDataBySet[0]);
+                setSelectedProduct(filteredModelsByDisplaySet[0]);
                 setSelectedColor(product?.display_color as string);
               }}
             >
@@ -203,7 +211,7 @@ export default function SeatCoverColorSelector() {
             );
             // const isOutOfStock = !isAvailableColor || product?.quantity === '0'; // leaving this here if we need to go back to showing out of stock
             const isOutOfStock = false;
-            const seatCover = getModelDataBySet.find(
+            const seatCover = filteredModelsByDisplaySet.find(
               (seatCover) =>
                 seatCover?.display_color?.toLowerCase() ===
                 product?.display_color?.toLowerCase()
@@ -217,7 +225,7 @@ export default function SeatCoverColorSelector() {
                 onClick={() => {
                   setColorIndex(index);
                   if (!seatCover) {
-                    const matchingColor = showColors.find(
+                    const matchingColor = ALL_SEAT_COLORS.find(
                       (color) =>
                         color.display_color.toLowerCase() ===
                         product?.display_color?.toLowerCase()
@@ -226,10 +234,12 @@ export default function SeatCoverColorSelector() {
                     // Don't have time to test
                     setSelectedProduct({
                       ...matchingColor,
-                      make: getModelDataBySet[0].make,
-                      model: getModelDataBySet[0].model,
-                      year_generation: getModelDataBySet[0].year_generation,
-                      parent_generation: getModelDataBySet[0].parent_generation,
+                      make: filteredModelsByDisplaySet[0].make,
+                      model: filteredModelsByDisplaySet[0].model,
+                      year_generation:
+                        filteredModelsByDisplaySet[0].year_generation,
+                      parent_generation:
+                        filteredModelsByDisplaySet[0].parent_generation,
                       ...(selectedSetDisplay === 'full'
                         ? { msrp: 279.95, price: 560 }
                         : { msrp: 199.95, price: 400 }),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -105,9 +105,21 @@ export function modelDataTransformer({
   const filteredAndSortedData = finalFilteredData
     ?.filter((product) => product.msrp)
     .sort((a, b) => {
+      // Preorder items should come last
+      const preorderA = a.preorder ? 1 : 0;
+      const preorderB = b.preorder ? 1 : 0;
+
+      // If one of the items has preorder, sort it after the non-preorder items
+      if (preorderA !== preorderB) {
+        return preorderA - preorderB;
+      }
+
+      // Existing year matching logic
       const yearMatchA = a.year_generation === params.year ? 0 : 1;
       const yearMatchB = b.year_generation === params.year ? 0 : 1;
+
       if (yearMatchA !== yearMatchB) return yearMatchA - yearMatchB;
+
       let colorIndexA = colorOrder.indexOf(
         a?.display_color as (typeof colorOrder)[number]
       );
@@ -120,6 +132,7 @@ export function modelDataTransformer({
 
       return colorIndexA - colorIndexB;
     });
+
   return filteredAndSortedData;
 }
 


### PR DESCRIPTION
## Car Cover Color Change
We want to have the same behavior as we have for seat covers.
- In Stock > Preorder
- BKRD > BKGR > GRBK

## Seat Cover Color Enhancement
There were some issues where preorder was not properly being sorted and the initial selection wasn't working correctly when switching to full seat set.

You can use this link to see:
https://coverland.com/seat-covers/leather/alfa-romeo/giulia/2017-2023

Some examples to check on the preview:
/seat-covers/leather/mercedes-benz/s-class/2014-2020?submodel=sedan
/seat-covers/leather/alfa-romeo/giulia/2017-2023
/seat-covers/leather/mazda/cx-5/2013-2024
/seat-covers/leather/toyota/corolla/2014-2019?submodel=sedan