### PR TITLE
Added Google Tag for preorder confirmation sheet

### DIFF
--- a/src/components/PDP/ProductDetailsPanel/ProductDetailsPanel.tsx
+++ b/src/components/PDP/ProductDetailsPanel/ProductDetailsPanel.tsx
@@ -1,11 +1,11 @@
 'use client';
 import { useState } from 'react';
 import { useCartContext } from '@/providers/CartProvider';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useStore } from 'zustand';
 import PreorderSheet from '@/components/cart/PreorderSheet';
 import { Separator } from '@/components/ui/separator';
-import { getCompleteSelectionData, TQueryParams } from '@/utils';
+import { getCompleteSelectionData, TPathParams, TQueryParams } from '@/utils';
 import AddToCart from '@/components/cart/AddToCart';
 import EditVehicle from '@/components/edit-vehicle/EditVehicle';
 import useStoreContext from '@/hooks/useStoreContext';
@@ -14,12 +14,14 @@ import ProductPricing from './ProductPricing';
 import FloorMatSelection from '../ProductVariantSelections/FloorMatSelection';
 import FreeDetails from '@/app/(main)/[productType]/components/FreeDetails';
 import FloorMatColorSelector from '../VariantColorSelectors/FloorMatColorSelector';
+import { handlePreorderAddToCartGoogleTag } from '@/hooks/useGoogleTagDataLayer';
 
 export default function ProductDetailsPanel({
   searchParams,
 }: {
   searchParams: TQueryParams;
 }) {
+  const params = useParams<TPathParams>();
   const store = useStoreContext();
   if (!store) throw new Error('Missing Provider in the tree');
   const modelData = useStore(store, (s) => s.modelData);
@@ -38,6 +40,13 @@ export default function ProductDetailsPanel({
   const handleAddToCart = () => {
     addToCart({ ...selectedProduct, quantity: 1 });
     if (selectedProduct.preorder) {
+      if (process.env.NEXT_PUBLIC_IS_PREVIEW !== 'PREVIEW') {
+        handlePreorderAddToCartGoogleTag(
+          selectedProduct,
+          params as TPathParams,
+          'preorder_1_add-to-cart'
+        );
+      }
       setAddToCartOpen(true);
       return;
     } else {

--- a/src/components/cart/PreorderFooter.tsx
+++ b/src/components/cart/PreorderFooter.tsx
@@ -1,11 +1,15 @@
 import { useCartContext } from '@/providers/CartProvider';
 import { Button } from '../ui/button';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import {
   PREORDER_CONFIRM,
   PREORDER_PREVIEW,
   PreorderStep,
 } from './PreorderSheet';
+import { handlePreorderAddToCartGoogleTag } from '@/hooks/useGoogleTagDataLayer';
+import useStoreContext from '@/hooks/useStoreContext';
+import { TPathParams } from '@/utils';
+import { useStore } from 'zustand';
 
 type PreorderFooterProps = {
   currentStep: PreorderStep;
@@ -17,13 +21,32 @@ const PreorderFooter = ({
   handleNextStep,
   checked,
 }: PreorderFooterProps) => {
+  const params = useParams<TPathParams>();
+  const store = useStoreContext();
+  if (!store) throw new Error('Missing Provider in the tree');
+  const selectedProduct = useStore(store, (s) => s.selectedProduct);
+
   const router = useRouter();
   const { setCartOpen } = useCartContext();
 
   const handleClick = () => {
     if (currentStep === PREORDER_PREVIEW) {
+      if (process.env.NEXT_PUBLIC_IS_PREVIEW !== 'PREVIEW') {
+        handlePreorderAddToCartGoogleTag(
+          selectedProduct,
+          params as TPathParams,
+          'preorder_2_discount-and-date'
+        );
+      }
       handleNextStep();
     } else if (currentStep === PREORDER_CONFIRM) {
+      if (process.env.NEXT_PUBLIC_IS_PREVIEW !== 'PREVIEW') {
+        handlePreorderAddToCartGoogleTag(
+          selectedProduct,
+          params as TPathParams,
+          'preorder_3_acknowledge-checkbox'
+        );
+      }
       setCartOpen(false);
       router.push('/checkout');
     }
@@ -39,9 +62,7 @@ const PreorderFooter = ({
         disabled={isDisabled}
         className="my-3 h-[48px] w-full bg-[#BE1B1B] text-base font-bold uppercase text-white disabled:bg-[#BE1B1B] md:h-[62px] md:text-lg"
       >
-        {currentStep === PREORDER_CONFIRM
-          ? 'Checkout'
-          : 'Pre-Order Now'}
+        {currentStep === PREORDER_CONFIRM ? 'Checkout' : 'Pre-Order Now'}
       </Button>
     </div>
   );

--- a/src/hooks/useGoogleTagDataLayer.ts
+++ b/src/hooks/useGoogleTagDataLayer.ts
@@ -52,11 +52,15 @@ const generateViewItemEvent = (
     discount: undefined,
     index: 0,
     item_brand: 'Coverland',
-    item_category: deslugify(params?.productType || ''),
-    item_category2: deslugify(params?.coverType || ''),
-    item_category3: deslugify(params?.make || ''),
-    item_category4: deslugify(params?.model || ''),
-    item_category5: params?.year || '',
+    item_category: deslugify(
+      params?.productType || selectedProduct?.type || ''
+    ),
+    item_category2: deslugify(
+      params?.coverType || selectedProduct?.display_id || ''
+    ),
+    item_category3: deslugify(params?.make || selectedProduct?.make || ''),
+    item_category4: deslugify(params?.model || selectedProduct?.model || ''),
+    item_category5: params?.year || selectedProduct?.parent_generation || '',
     item_category6: isComplete
       ? deslugify(selectedProduct?.submodel1 || '')
       : undefined,
@@ -275,7 +279,7 @@ export const handleAddToCartGoogleTag = (
   );
   const fullProductName =
     `${cartProduct.year_generation ?? ''} ${cartProduct.make ?? ''} ${cartProduct.model ?? ''} ${cartProduct.submodel1 ?? ''} ${cartProduct.submodel2 ?? ''} ${cartProduct.submodel3 ?? ''}`.trim();
-  const productName = `${fullProductName} ${cleanedDisplayId} ${cartProduct.type}`;
+  const productName = `${fullProductName} ${cleanedDisplayId} ${cartProduct?.type}`;
   window?.dataLayer?.push({ ecommerce: null }); // Clear the previous ecommerce object.
   window?.dataLayer?.push({
     event: 'add_to_cart',
@@ -292,7 +296,10 @@ export const handleAddToCartGoogleTag = (
           index: 0,
           item_brand: 'Coverland',
           item_category: deslugify(
-            params?.productType || cartProduct.product_type || ''
+            params?.productType ||
+              cartProduct?.product_type ||
+              cartProduct?.type ||
+              ''
           ),
           item_category2: deslugify(
             params?.coverType || cartProduct.display_id || ''
@@ -329,6 +336,66 @@ export const handleViewItemColorChangeGoogleTag = (
       currency: 'USD',
       value: isComplete ? msrp : undefined,
       items: [item],
+    },
+  });
+};
+
+export const handlePreorderAddToCartGoogleTag = (
+  cartProduct: IProductData,
+  params: TPathParams,
+  eventTitle:
+    | 'preorder_1_add-to-cart'
+    | 'preorder_2_discount-and-date'
+    | 'preorder_3_acknowledge-checkbox'
+) => {
+  // const price = parseFloat(cartProduct?.price || '0') || 0;
+  const msrp = parseFloat(cartProduct?.msrp || '0') || 0;
+  // const discount: number = price - msrp;
+  const cleanedDisplayId = removeMakeFromDisplayId(
+    cartProduct.display_id as string,
+    cartProduct.make as string
+  );
+  const fullProductName =
+    `${cartProduct.year_generation ?? ''} ${cartProduct.make ?? ''} ${cartProduct.model ?? ''} ${cartProduct.submodel1 ?? ''} ${cartProduct.submodel2 ?? ''} ${cartProduct.submodel3 ?? ''}`.trim();
+  const productName = `${fullProductName} ${cleanedDisplayId} ${cartProduct?.type}`;
+  window?.dataLayer?.push({ ecommerce: null }); // Clear the previous ecommerce object.
+  window?.dataLayer?.push({
+    event: eventTitle,
+    ecommerce: {
+      currency: 'USD',
+      value: msrp,
+      items: [
+        {
+          item_id: cartProduct.sku,
+          item_name: productName,
+          affiliation: undefined,
+          coupon: undefined,
+          discount: undefined, // Removed temporarily because we transfer the promotional price or something
+          index: 0,
+          item_brand: 'Coverland',
+          item_category: deslugify(
+            params?.productType ||
+              cartProduct?.product_type ||
+              cartProduct?.type ||
+              ''
+          ),
+          item_category2: deslugify(
+            params?.coverType || cartProduct.display_id || ''
+          ),
+          item_category3: deslugify(params?.make || cartProduct.make || ''),
+          item_category4: deslugify(params?.model || cartProduct.model || ''),
+          item_category5: params?.year || cartProduct.parent_generation || '',
+          item_category6: deslugify(cartProduct?.submodel1 || ''),
+          item_category7: deslugify(cartProduct?.submodel2 || ''),
+          item_category8: deslugify(cartProduct?.submodel3 || ''),
+          item_list_id: undefined,
+          item_list_name: undefined,
+          item_variant: cartProduct?.display_color,
+          location_id: undefined,
+          price: msrp,
+          quantity: 1,
+        },
+      ],
     },
   });
 };


### PR DESCRIPTION
From Vasiliy:

Hi William, could you please help with the event tracking for pre-orders?
We would need to track clicks through the buttons while client is placing preorder to be able to see it as a funnel.
I see 3 steps there that we need to track
"preorder_1_add-to-cart" for "Pre-order & save big"
"preorder_2_discount-and-date" for "Pre-order now"
"preorder_3_acknowledge-checkbox" for "Checkout"
Could you please add parameters of the product to the event? SKU or URL or something what would help us to distinguish one product to the other?
Here are the instructions:
https://support.google.com/tagmanager/answer/13034206?hl=en
It seems like I might try to take care of the GTM part, but can't really do anything with the code on the website. And parameters is a topic where I might need extra education.
Here is about parameters: https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtag#implementation